### PR TITLE
feat: Refine revenue, sockets, auth and UI modals

### DIFF
--- a/Backend/app/config/database.js
+++ b/Backend/app/config/database.js
@@ -12,7 +12,6 @@ const connectDatabase = async () => {
     }
 
     await mongoose.connect(mongoUri, {
-      dbName: 'test',
       retryWrites: true,
       w: 'majority',
       serverSelectionTimeoutMS: 5000,
@@ -20,6 +19,7 @@ const connectDatabase = async () => {
       maxPoolSize: 10,
       minPoolSize: 2
     });
+
 
     console.log('✅ MongoDB connected to database:', mongoose.connection.name);
   } catch (error) {

--- a/Backend/app/controllers/authController.js
+++ b/Backend/app/controllers/authController.js
@@ -6,10 +6,14 @@ const login = async (req, res) => {
   try {
     const { username, password } = req.body;
 
+    console.log('[Auth] Login attempt for:', username);
+
     const admin = await User.findOne({ 
       email: username,
       userType: { $in: ['admin', 'superadmin'] }
     });
+    
+    console.log('[Auth] Admin found:', admin ? 'YES' : 'NO', admin ? `(type: ${admin.userType})` : '');
     
     if (!admin) {
       return res.status(401).json({
@@ -19,13 +23,16 @@ const login = async (req, res) => {
     }
 
     if (!admin.password) {
+      console.log('[Auth] No password set for admin user');
       return res.status(401).json({
         success: false,
         error: 'Invalid credentials'
       });
     }
 
+    console.log('[Auth] Comparing password...');
     const isValidPassword = await bcrypt.compare(password, admin.password);
+    console.log('[Auth] Password valid:', isValidPassword);
     
     if (!isValidPassword) {
       return res.status(401).json({

--- a/Backend/app/controllers/dashboardController.js
+++ b/Backend/app/controllers/dashboardController.js
@@ -22,8 +22,8 @@ const getStats = async (req, res) => {
     const activeJobs = await Job.countDocuments({ status: { $in: ['open', 'in_progress'] } });
     const onlineUsers = await User.countDocuments({ isOnline: true });
     
-    const completedTransactions = await Transaction.find({ status: 'completed' });
-    const totalRevenue = completedTransactions.reduce((sum, t) => sum + (t.amount || 0), 0);
+    const completedFeeTransactions = await Transaction.find({ status: 'completed', type: 'platform_fee' });
+    const totalRevenue = completedFeeTransactions.reduce((sum, t) => sum + (t.amount || 0), 0);
     
     const pendingFeeRecords = await FeeRecord.find({ 
       status: { $in: ['pending', 'overdue'] } 
@@ -46,11 +46,12 @@ const getStats = async (req, res) => {
       status: 'completed', 
       completedAt: { $gte: today } 
     });
-    const todayTransactions = await Transaction.find({ 
+    const todayFeeTransactions = await Transaction.find({ 
       status: 'completed',
+      type: 'platform_fee',
       completedAt: { $gte: today }
     });
-    const revenueToday = todayTransactions.reduce((sum, t) => sum + (t.amount || 0), 0);
+    const revenueToday = todayFeeTransactions.reduce((sum, t) => sum + (t.amount || 0), 0);
 
     const verifiedProviderIds = await CredentialVerification.distinct('userId', { 
       status: 'approved' 
@@ -368,6 +369,7 @@ const getRevenueChart = async (req, res) => {
 
         const dayTransactions = await Transaction.find({
           status: 'completed',
+          type: 'platform_fee',
           $or: [
             { completedAt: { $gte: startDate, $lte: endDate } },
             { 
@@ -398,6 +400,7 @@ const getRevenueChart = async (req, res) => {
 
         const weekTransactions = await Transaction.find({
           status: 'completed',
+          type: 'platform_fee',
           $or: [
             { completedAt: { $gte: startDate, $lte: endDate } },
             { 
@@ -445,6 +448,7 @@ const getStatsComparison = async (req, res) => {
 
     const currentMonthRevenueDocs = await Transaction.find({
       status: 'completed',
+      type: 'platform_fee',
       $or: [
         { completedAt: { $gte: currentMonthStart } },
         { completedAt: null, createdAt: { $gte: currentMonthStart } }
@@ -454,6 +458,7 @@ const getStatsComparison = async (req, res) => {
 
     const lastMonthRevenueDocs = await Transaction.find({
       status: 'completed',
+      type: 'platform_fee',
       $or: [
         { completedAt: { $gte: lastMonthStart, $lte: lastMonthEnd } },
         { completedAt: null, createdAt: { $gte: lastMonthStart, $lte: lastMonthEnd } }

--- a/Backend/app/socket/socketHandlers.js
+++ b/Backend/app/socket/socketHandlers.js
@@ -18,6 +18,9 @@ const MOBILE_BACKEND_URL = process.env.MOBILE_BACKEND_URL || 'http://localhost:8
 
 const setupSocketHandlers = (io) => {
   adminNamespace = io.of('/admin');
+  
+  // Store main io instance for use in change stream
+  global.io = io;
 
   setupChatSupportChangeStream();
 
@@ -112,11 +115,10 @@ const setupSocketHandlers = (io) => {
           };
 
           // Send confirmation back to the admin who sent it
-          // NOTE: Commented out to prevent duplicate messages. The MongoDB change stream
-          // will automatically broadcast this message to all connected clients.
-          // socket.emit('support:new_message', messageData);
+          // NOTE: Direct emit enabled as fallback when change streams are unavailable
+          socket.emit('support:new_message', messageData);
           // Also broadcast to anyone in the support room
-          // adminNamespace.to(`support:${data.chatSupportId}`).emit('support:new_message', messageData);
+          adminNamespace.to(`support:${data.chatSupportId}`).emit('support:new_message', messageData);
         } catch (error) {
           console.error('❌ Error sending admin message:', error.message);
           socket.emit('support:message_error', {
@@ -702,8 +704,8 @@ const setupChatSupportChangeStream = () => {
                 });
               }
 
-              if (mainIo) {
-                mainIo.to(`support:${chatSupportId}`).emit('support:chat_updated', {
+              if (global.io) {
+                global.io.to(`support:${chatSupportId}`).emit('support:chat_updated', {
                   chatSupportId,
                   updates,
                   timestamp: new Date()
@@ -718,12 +720,22 @@ const setupChatSupportChangeStream = () => {
     });
 
     changeStream.on('error', (error) => {
-      console.error('Chat support change stream error:', error);
+      if (error.codeName === 'Location40573') {
+        console.warn('⚠️  MongoDB change streams require replica set. Falling back to direct socket emits.');
+        console.log('💡 To enable change streams, configure MongoDB as a replica set: https://docs.mongodb.com/manual/tutorial/convert-standalone-to-replica-set/');
+      } else {
+        console.error('Chat support change stream error:', error);
+      }
     });
 
     chatSupportChangeStream = changeStream;
   } catch (error) {
-    console.error('Failed to setup chat support change stream:', error);
+    if (error.codeName === 'Location40573') {
+      console.warn('⚠️  MongoDB change streams require replica set. Chat will work without real-time updates.');
+      console.log('💡 To enable change streams, configure MongoDB as a replica set: https://docs.mongodb.com/manual/tutorial/convert-standalone-to-replica-set/');
+    } else {
+      console.error('Failed to setup chat support change stream:', error);
+    }
   }
 };
 

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -159,8 +159,9 @@ const gracefulShutdown = async () => {
 
 process.on('SIGTERM', gracefulShutdown);
 
-// Export io instance for use in other modules
-module.exports.getIO = () => io;
-process.on('SIGINT', gracefulShutdown);
+module.exports = { 
+  io,
+  getIO: () => io 
+};
 
-module.exports = { io };
+process.on('SIGINT', gracefulShutdown);

--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -71,7 +71,7 @@ const AppRoutes: React.FC = () => {
         <Route path="/users/providers" element={<ProtectedRoute><Layout title="Service Providers"><Users /></Layout></ProtectedRoute>} />
         <Route path="/users/flagged" element={<ProtectedRoute><Layout title="Flagged & Suspended"><Users /></Layout></ProtectedRoute>} />
         <Route path="/users/deleted" element={<ProtectedRoute><Layout title="Deleted Users"><Users /></Layout></ProtectedRoute>} />
-        <Route path="/jobs" element={<ProtectedRoute><Layout title="Jobs"><Jobs /></Layout></ProtectedRoute>} />
+        <Route path="/jobs" element={<ProtectedRoute><Layout title="Jobs Management"><Jobs /></Layout></ProtectedRoute>} />
         <Route path="/jobs/archived" element={<ProtectedRoute><Layout title="Archived Jobs"><ArchivedJobs /></Layout></ProtectedRoute>} />
         <Route path="/transactions/fee-records" element={<ProtectedRoute><Layout title="Fee Records"><Transactions /></Layout></ProtectedRoute>} />
         <Route path="/transactions/top-up" element={<ProtectedRoute><Layout title="Top-up Transactions"><Transactions /></Layout></ProtectedRoute>} />

--- a/Frontend/src/components/Dashboard/StatsCard.tsx
+++ b/Frontend/src/components/Dashboard/StatsCard.tsx
@@ -4,6 +4,7 @@ import { LucideIcon, ArrowUpRight, ArrowUp, ArrowDown } from 'lucide-react';
 interface StatsCardProps {
   title: string;
   value: string;
+  subtitle?: string;
   icon: LucideIcon;
   trend?: {
     value: number;
@@ -14,6 +15,8 @@ interface StatsCardProps {
   onClick?: () => void;
   isActive?: boolean;
   smallIcon?: boolean;
+  horizontalMobile?: boolean;
+  compact?: boolean;
 }
 
 const MiniChart = ({ isPositive, isSolid }: { isPositive: boolean; isSolid: boolean }) => {
@@ -43,7 +46,7 @@ const MiniChart = ({ isPositive, isSolid }: { isPositive: boolean; isSolid: bool
   );
 };
 
-const StatsCard: React.FC<StatsCardProps> = ({ title, value, icon: Icon, trend, color, variant = 'default', onClick, isActive, smallIcon }) => {
+const StatsCard: React.FC<StatsCardProps> = ({ title, value, subtitle, icon: Icon, trend, color, variant = 'default', onClick, isActive, smallIcon, horizontalMobile, compact = false }) => {
   const isSolid = variant === 'solid';
   const isTinted = variant === 'tinted';
 
@@ -112,25 +115,50 @@ const StatsCard: React.FC<StatsCardProps> = ({ title, value, icon: Icon, trend, 
   return (
     <div 
       onClick={onClick}
-      className={`rounded-2xl flex flex-col ${trend ? 'justify-center sm:justify-between' : 'justify-center'} overflow-hidden ${trend ? 'p-3 sm:p-5 h-[96px] sm:h-[160px]' : 'p-3 sm:p-4 h-[88px] sm:h-[102px]'} ${containerClasses} ${onClick ? 'cursor-pointer' : ''}`}
+      className={`rounded-2xl flex flex-col ${trend ? 'justify-center sm:justify-between' : 'justify-center'} overflow-hidden ${horizontalMobile ? (compact ? 'p-2 sm:p-3 h-[72px] sm:h-[102px]' : (trend ? 'p-3 sm:p-5 h-[96px] sm:h-[102px]' : 'p-3 sm:p-5 h-[88px] sm:h-[102px]')) : (trend ? 'p-3 sm:p-5 h-[96px] sm:h-[160px]' : 'p-3 sm:p-4 h-[88px] sm:h-[102px]')} ${containerClasses} ${onClick ? 'cursor-pointer' : ''}`}
     >
       {/* Mobile Layout - Widget Style */}
-      <div className="flex sm:hidden flex-col h-full w-full relative">
-        <div className="flex justify-between items-start w-full absolute top-0 left-0 right-0">
-          <div className={`w-[30px] h-[30px] rounded-[10px] flex items-center justify-center flex-shrink-0 ${iconCircleClasses}`}>
-            <Icon className="w-[18px] h-[18px]" />
-          </div>
-          {trend && (
-            <span className={`text-[11px] font-bold whitespace-nowrap mt-1 ${trendColorClass}`}>
-              {trend.isPositive ? '+' : ''}{trend.value}{!isSolid && trend.value !== 0 ? '%' : ''}
-            </span>
-          )}
-        </div>
-        
-        <div className="flex flex-col items-start justify-center flex-1 w-full min-w-0 mt-5 pt-2">
-          <span className="text-[20px] font-black tracking-tight truncate max-w-full leading-none" title={value}>{value}</span>
-          <span className={`text-[10px] font-semibold opacity-85 uppercase tracking-wide truncate max-w-full mt-1.5 ${titleClasses}`}>{title}</span>
-        </div>
+      <div className={`flex sm:hidden ${horizontalMobile ? 'flex-row items-center gap-4 p-1' : 'flex-col relative'} h-full w-full`}>
+        {horizontalMobile ? (
+          <>
+            <div className={`${compact ? 'w-[36px] h-[36px] rounded-lg' : 'w-[44px] h-[44px] rounded-xl'} flex items-center justify-center flex-shrink-0 ${iconCircleClasses}`}>
+              <Icon className={compact ? "w-5 h-5" : "w-6 h-6"} />
+            </div>
+            <div className="flex flex-col flex-1 min-w-0">
+              <div className="flex items-center justify-between w-full">
+                <span className={`${compact ? 'text-[18px]' : 'text-[22px]'} font-black tracking-tight truncate leading-none`} title={value}>{value}</span>
+                {trend && (
+                  <span className={`text-[11px] font-bold whitespace-nowrap ${trendColorClass}`}>
+                    {trend.isPositive ? '+' : ''}{trend.value}{!isSolid && trend.value !== 0 ? '%' : ''}
+                  </span>
+                )}
+              </div>
+              <span className={`text-[10px] font-black uppercase tracking-[0.1em] mt-1.5 opacity-80 ${titleClasses}`}>
+                {title === 'Revenue' ? 'Total Revenue' : title}
+              </span>
+              {subtitle && <span className="text-[10px] font-bold text-white/70 mt-0.5 truncate">{subtitle}</span>}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="flex justify-between items-start w-full absolute top-0 left-0 right-0">
+              <div className={`w-[30px] h-[30px] rounded-[10px] flex items-center justify-center flex-shrink-0 ${iconCircleClasses}`}>
+                <Icon className="w-[18px] h-[18px]" />
+              </div>
+              {trend && (
+                <span className={`text-[11px] font-bold whitespace-nowrap mt-1 ${trendColorClass}`}>
+                  {trend.isPositive ? '+' : ''}{trend.value}{!isSolid && trend.value !== 0 ? '%' : ''}
+                </span>
+              )}
+            </div>
+            
+            <div className="flex flex-col items-start justify-center flex-1 w-full min-w-0 mt-5 pt-2">
+              <span className="text-[20px] font-black tracking-tight truncate max-w-full leading-none" title={value}>{value}</span>
+              {subtitle && <span className="text-[12px] font-bold text-gray-500 mt-0.5 truncate max-w-full">{subtitle}</span>}
+              <span className={`text-[10px] font-semibold opacity-85 uppercase tracking-wide truncate max-w-full mt-1 ${titleClasses}`}>{title}</span>
+            </div>
+          </>
+        )}
       </div>
 
       {/* Desktop Layout - Orginal Full Size */}
@@ -153,9 +181,16 @@ const StatsCard: React.FC<StatsCardProps> = ({ title, value, icon: Icon, trend, 
 
       <div className={`hidden sm:flex justify-between items-end ${trend ? 'mt-auto pt-2' : 'mt-2 pt-1'} gap-2 relative w-full`}>
         <div className="flex flex-col gap-1.5 min-w-0 z-10 w-auto">
-          <span className="text-3xl font-bold tracking-tight truncate max-w-full" title={value}>
-            {value}
-          </span>
+          <div className="flex flex-col">
+            <span className="text-3xl font-bold tracking-tight truncate max-w-full" title={value}>
+              {value}
+            </span>
+            {subtitle && (
+              <span className="text-sm font-bold text-gray-500 mt-1 truncate max-w-full">
+                {subtitle}
+              </span>
+            )}
+          </div>
           {trend && (
             <div className={`flex items-center gap-1 text-xs font-semibold ${trendColorClass}`}>
               {trend.isPositive ? <ArrowUp className="w-3 h-3 flex-shrink-0" /> : <ArrowDown className="w-3 h-3 flex-shrink-0" />}

--- a/Frontend/src/components/Layout/Layout.tsx
+++ b/Frontend/src/components/Layout/Layout.tsx
@@ -640,14 +640,19 @@ const Layout: React.FC<LayoutProps> = ({ children, title }) => {
                       switch (title) {
                         case 'Dashboard': return 'Welcome back! Your service marketplace\'s performance view';
                         case 'All Users':
+                          return 'Monitor and manage all user accounts across the platform';
                         case 'Customers':
+                          return 'Manage customer accounts and their service requests';
                         case 'Service Providers':
+                          return 'Manage service providers and their verification status';
                         case 'Flagged & Suspended':
+                          return 'Review and manage restricted, suspended, and banned user accounts';
                         case 'Deleted Users':
-                          return 'Manage customer and service provider accounts';
-                        case 'Jobs':
+                          return 'View and manage soft deleted user accounts';
+                        case 'Jobs Management':
+                          return 'Monitor and manage all service requests across the platform';
                         case 'Archived Jobs':
-                          return 'View and manage service job requests';
+                          return 'View and manage job listings that have been hidden or removed';
                         case 'Fee Records':
                         case 'Top-up Transactions':
                         case 'Cashout Transactions':

--- a/Frontend/src/components/Modals/JobDetailsModal.tsx
+++ b/Frontend/src/components/Modals/JobDetailsModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { createPortal } from 'react-dom';
 import {
   X,
   ChevronDown,
@@ -7,7 +8,17 @@ import {
   Eye,
   EyeOff,
   Trash2,
-  RotateCcw
+  RotateCcw,
+  MapPin,
+  Calendar,
+  Briefcase,
+  DollarSign,
+  Users,
+  Phone,
+  Mail,
+  CreditCard,
+  Hash,
+  ExternalLink
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import toast from 'react-hot-toast';
@@ -15,6 +26,7 @@ import VerificationStatusBadge from '../UI/VerificationStatusBadge';
 import UserTypeBadge from '../UI/UserTypeBadge';
 import { jobsService } from '../../services';
 import type { Job, Application } from '../../types/jobs.types';
+import { SidebarContext } from '../Layout/Layout';
 
 interface JobDetailsModalProps {
   isOpen: boolean;
@@ -39,6 +51,18 @@ const JobDetailsModal: React.FC<JobDetailsModalProps> = ({
   const [applicants, setApplicants] = useState<Application[]>([]);
   const [loadingApplicants, setLoadingApplicants] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null);
+  const { setIsHeaderHidden } = React.useContext(SidebarContext);
+
+  useEffect(() => {
+    if (setIsHeaderHidden) {
+      setIsHeaderHidden(isOpen);
+    }
+    return () => {
+      if (setIsHeaderHidden) {
+        setIsHeaderHidden(false);
+      }
+    };
+  }, [isOpen, setIsHeaderHidden]);
 
   useEffect(() => {
     if (isOpen && job) {
@@ -172,205 +196,242 @@ const JobDetailsModal: React.FC<JobDetailsModalProps> = ({
     });
   };
 
-  return (
+  return createPortal(
     <>
       <div
-        className="fixed inset-0 bg-black bg-opacity-50 z-40 transition-opacity"
+        className="fixed inset-0 bg-black bg-opacity-50 z-[90] transition-opacity"
         onClick={onClose}
       />
 
-      <div className="fixed right-0 top-0 h-full w-full md:w-[550px] bg-gray-50 z-50 shadow-2xl flex flex-col">
-        <div className="px-6 py-5 border-b border-gray-300 bg-gray-50 flex-shrink-0 z-10">
-          <div className="flex items-center justify-between mb-2">
-            <h3 className="text-lg font-semibold text-gray-900">Job Details</h3>
+      <div className="fixed right-0 top-0 h-full w-full md:w-[550px] bg-gray-50 z-[100] shadow-2xl flex flex-col">
+        <div className="px-6 py-4 border-b border-gray-200 bg-white flex-shrink-0 z-10">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 mb-0.5">
+                <h3 className="text-lg font-black text-gray-900 truncate leading-tight">
+                  {job.title}
+                </h3>
+                <div className="flex-shrink-0 flex gap-1 transform scale-[0.85] origin-left">
+                  <VerificationStatusBadge isVerified={job.user?.isVerified || false} />
+                  <UserTypeBadge userType={job.user?.userType || 'client'} />
+                </div>
+              </div>
+              <button
+                onClick={() => copyToClipboard(job._id)}
+                className="flex items-center gap-1.5 group"
+                title="Click to copy Job ID"
+              >
+                <span className="text-[10px] font-mono font-bold text-gray-400 group-hover:text-blue-600 transition-colors">
+                  ID: {job._id}
+                </span>
+                <span className="text-[8px] font-black text-gray-300 group-hover:text-blue-500 uppercase tracking-tighter transition-colors">
+                  • Click to Copy
+                </span>
+              </button>
+            </div>
             <button
               onClick={onClose}
-              className="p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-200 rounded-lg transition-colors"
+              className="p-1 -mr-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors flex-shrink-0"
               aria-label="Close modal"
             >
               <X className="h-5 w-5" />
             </button>
           </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <button
-                onClick={() => copyToClipboard(job._id)}
-                className="text-xs text-gray-500 hover:text-blue-600 cursor-pointer transition-colors text-left"
-                title="Click to copy"
-              >
-                Job ID: {job._id}
-              </button>
-            </div>
-            <div className="text-right">
-              <p className="text-xs text-gray-500 inline">Job Title: </p>
-              <p className="text-base font-semibold text-gray-900 inline">{job.title}</p>
-            </div>
-          </div>
         </div>
 
-        <div className="flex-1 overflow-y-auto">
-          <div className="p-6">
-            <div className="flex items-center gap-4 pb-6">
+        <div className="flex-1 overflow-y-auto custom-scrollbar bg-white">
+          <div className="p-0">
+            {/* User Quick Profile - No Container */}
+            <div className="px-6 py-6 flex items-center gap-4">
               {job.user?.profileImage ? (
-                <img
-                  src={job.user.profileImage}
-                  alt={job.user.name}
-                  className="w-16 h-16 rounded-full object-cover"
-                />
+                <div className="relative">
+                  <img
+                    src={job.user.profileImage}
+                    alt={job.user.name}
+                    className="w-14 h-14 rounded-full object-cover border border-gray-100"
+                  />
+                </div>
               ) : (
-                <div className="w-16 h-16 rounded-full bg-gray-300 flex items-center justify-center">
-                  <span className="text-2xl font-semibold text-gray-700">
+                <div className="w-14 h-14 rounded-full bg-blue-50 flex items-center justify-center">
+                  <span className="text-xl font-black text-blue-600">
                     {getInitials(job.user?.name || 'U')}
                   </span>
                 </div>
               )}
-              <div className="flex-1">
-                <h4 className="text-lg font-bold text-gray-900 mb-1">{job.user?.name || 'Unknown User'}</h4>
-                {(job.user?.firstName || job.user?.lastName) && (
-                  <p className="text-sm text-gray-600 mb-1">
-                    {job.user?.firstName || ''} {job.user?.lastName || ''}
-                  </p>
-                )}
-                <p className="text-sm text-gray-600 inline">Email: </p>
-                <p className="text-sm text-gray-900 inline">{job.user?.email || 'No email'}</p>
-                <p className="text-sm text-gray-900 mt-1">KYD:{job.user?._id?.slice(-6) || '000000'}</p>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 mb-0.5">
+                  <h4 className="text-base font-black text-gray-900 truncate">{job.user?.name || 'Unknown User'}</h4>
+                  {job.user?.isVerified && <VerificationStatusBadge isVerified={true} size="sm" hideLabel />}
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <div className="flex items-center gap-1.5 text-gray-500">
+                    <Mail className="h-3 w-3" />
+                    <span className="text-[11px] font-medium truncate">{job.user?.email || 'No email'}</span>
+                  </div>
+                  <div className="flex items-center gap-1.5 text-gray-400">
+                    <Hash className="h-3 w-3" />
+                    <span className="text-[10px] font-bold">KYD: {job.user?._id?.slice(-8).toUpperCase() || '00000000'}</span>
+                  </div>
+                </div>
               </div>
-              <div className="flex flex-col gap-2">
-                <VerificationStatusBadge isVerified={job.user?.isVerified || false} />
+              <div className="flex-shrink-0">
                 <UserTypeBadge userType={job.user?.userType || 'client'} />
               </div>
             </div>
 
-            <div className="border-t border-gray-300 -mx-6" />
-            <div className="flex -mx-6">
-              <div className="flex-1 py-6 px-6">
-                <p className="text-base font-semibold text-gray-900 mb-2">Budget:</p>
-                <p className="text-base text-gray-700">{job.budget ? formatCurrency(job.budget) : 'Not specified'}</p>
-              </div>
-              <div className="border-l border-gray-300 flex-1 py-6 pl-4 pr-6">
-                <p className="text-base font-semibold text-gray-900 mb-2">Applicants:</p>
-                <p className="text-base text-gray-700">{job.applicationCount || 0}</p>
-              </div>
-            </div>
-            <div className="border-t border-gray-300 -mx-6" />
-
-            <div className="mb-6 mt-6">
-              <p className="text-base font-semibold text-gray-900 mb-3">Contact Information:</p>
-              <div className="space-y-2">
-                <div>
-                  <p className="text-xs text-gray-500 mb-1">Address</p>
-                  <p className="text-sm text-gray-900">{job.locationDisplay || 'Location not specified'}</p>
+            <div className="grid grid-cols-2 border-y border-gray-100">
+              <div className="px-6 py-6 bg-indigo-50/20 border-r border-gray-100">
+                <div className="flex items-center gap-2 mb-1">
+                  <DollarSign className="h-3 w-3 text-indigo-500" />
+                  <span className="text-[9px] font-black text-indigo-500 uppercase tracking-widest">Budget</span>
                 </div>
-                <div>
-                  <p className="text-xs text-gray-500 mb-1">Brgy#</p>
-                  <p className="text-sm text-gray-900">{job.user?.barangay || 'Not specified'}</p>
-                </div>
-                <div>
-                  <p className="text-xs text-gray-500 mb-1">City</p>
-                  <p className="text-sm text-gray-900">{job.user?.city || 'Not specified'}</p>
-                </div>
-                <div>
-                  <p className="text-xs text-gray-500 mb-1">Phone #</p>
-                  <p className="text-sm text-gray-900">{job.user?.phone || 'Not provided'}</p>
-                </div>
-              </div>
-            </div>
-
-            <div className="border-t border-gray-300 mb-6 -mx-6" />
-
-            <div className="grid grid-cols-2 gap-4 mb-6">
-              <div>
-                <p className="text-xs text-gray-500 mb-1">Job Posted On:</p>
-                <p className="text-sm font-medium text-gray-900">
-                  {new Date(job.createdAt).toLocaleDateString('en-US', {
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric'
-                  })}
+                <p className="text-xl font-black text-indigo-900">
+                  {job.budget ? formatCurrency(job.budget) : 'Unset'}
                 </p>
               </div>
-              <div>
-                <p className="text-xs text-gray-500 mb-1">Category:</p>
-                <p className="text-sm font-medium text-gray-900 capitalize">
-                  {(job.category || '').replace(/([A-Z])/g, ' $1').trim()}
+              
+              <div className="px-6 py-6 bg-emerald-50/20">
+                <div className="flex items-center gap-2 mb-1">
+                  <Users className="h-3 w-3 text-emerald-500" />
+                  <span className="text-[9px] font-black text-emerald-600 uppercase tracking-widest">Applicants</span>
+                </div>
+                <p className="text-xl font-black text-emerald-900">
+                  {job.applicationCount || 0}
                 </p>
-              </div>
-              <div>
-                <p className="text-xs text-gray-500 mb-1">Budget:</p>
-                <p className="text-sm font-medium text-gray-900">{job.budget ? formatCurrency(job.budget) : 'Not specified'}</p>
-              </div>
-              <div>
-                <p className="text-xs text-gray-500 mb-1">Payment Method:</p>
-                <p className="text-sm font-medium text-gray-900 capitalize">{job.paymentMethod}</p>
               </div>
             </div>
 
-            <div className="border-t border-gray-300 mb-6 -mx-6" />
+            {/* Service Attributes Section */}
+            <div className="px-6 py-8">
+              <div className="flex items-center gap-2 mb-6">
+                <div className="h-px flex-1 bg-gray-100" />
+                <h5 className="text-[10px] font-black text-gray-400 uppercase tracking-[0.2em] px-2 flex items-center gap-2">
+                  <Briefcase className="h-3 w-3" />
+                  Service Details
+                </h5>
+                <div className="h-px flex-1 bg-gray-100" />
+              </div>
 
-            <div>
-              <button
-                onClick={() => setShowMediaAttachments(!showMediaAttachments)}
-                className="w-full flex items-center justify-between text-base font-semibold text-gray-900 mb-3 hover:text-gray-700 transition-colors"
-              >
-                <span>Media Attachments ({job.media && job.media.length > 0 ? job.media.length : 0})</span>
-                {showMediaAttachments ? (
-                  <ChevronUp className="h-5 w-5" />
-                ) : (
-                  <ChevronDown className="h-5 w-5" />
-                )}
-              </button>
+              <div className="grid grid-cols-2 gap-y-8 gap-x-6">
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5 text-gray-400">
+                    <Calendar className="h-3 w-3" />
+                    <span className="text-[9px] font-black uppercase tracking-widest">Posted On</span>
+                  </div>
+                  <p className="text-sm font-bold text-gray-900">
+                    {new Date(job.createdAt).toLocaleDateString('en-US', {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric'
+                    })}
+                  </p>
+                </div>
 
-              {showMediaAttachments && (
-                <div className="grid grid-cols-2 gap-3 mt-3">
-                  {job.media && job.media.length > 0 ? (
-                    job.media.map((url, index) => (
-                      <div
-                        key={index}
-                        className="aspect-video border border-gray-300 rounded-lg overflow-hidden cursor-pointer hover:opacity-90 transition-opacity group relative"
-                        onClick={() => setSelectedImageIndex(index)}
-                      >
-                        <img
-                          src={url}
-                          alt={`Job media ${index + 1}`}
-                          className="w-full h-full object-cover"
-                        />
-                        <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all flex items-center justify-center">
-                          <Eye className="text-white opacity-0 group-hover:opacity-100 transition-opacity h-8 w-8" />
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5 text-gray-400">
+                    <Briefcase className="h-3 w-3" />
+                    <span className="text-[9px] font-black uppercase tracking-widest">Profession</span>
+                  </div>
+                  <p className="text-sm font-bold text-gray-900 capitalize">
+                    {(job.category || '').replace(/([A-Z])/g, ' $1').trim()}
+                  </p>
+                </div>
+
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5 text-gray-400">
+                    <CreditCard className="h-3 w-3" />
+                    <span className="text-[9px] font-black uppercase tracking-widest">Payment</span>
+                  </div>
+                  <p className="text-sm font-bold text-gray-900 capitalize">
+                    {job.paymentMethod}
+                  </p>
+                </div>
+
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-1.5 text-gray-400">
+                    <MapPin className="h-3 w-3" />
+                    <span className="text-[9px] font-black uppercase tracking-widest">Region</span>
+                  </div>
+                  <p className="text-sm font-bold text-gray-900 truncate">
+                    {job.user?.barangay || 'N/A'} • {job.user?.city || 'N/A'}
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-8 pt-8 border-t border-gray-50">
+                <div className="flex items-center gap-1.5 text-gray-400 mb-3">
+                  <MapPin className="h-3 w-3" />
+                  <span className="text-[9px] font-black uppercase tracking-widest">Pick-up / Service Location</span>
+                </div>
+                <p className="text-sm font-bold text-gray-700 leading-relaxed bg-gray-50/50 p-4 rounded-xl border border-gray-100/50">
+                  {job.locationDisplay || 'Location not specified'}
+                </p>
+              </div>
+            </div>
+            
+            <div className="p-6 space-y-4">
+              <div className="overflow-hidden">
+                <button
+                  onClick={() => setShowMediaAttachments(!showMediaAttachments)}
+                  className={`w-full flex items-center justify-between py-2 text-[10px] font-black text-gray-400 hover:text-blue-500 uppercase tracking-[0.2em] transition-colors`}
+                >
+                  <div className="flex items-center gap-2">
+                    <Eye className="h-3 w-3" />
+                    <span>Media Attachments ({job.media?.length || 0})</span>
+                  </div>
+                  <ChevronDown className={`h-3 w-3 transition-transform duration-300 ${showMediaAttachments ? 'rotate-180' : ''}`} />
+                </button>
+
+                {showMediaAttachments && (
+                  <div className="pt-4 grid grid-cols-2 gap-3">
+                    {job.media && job.media.length > 0 ? (
+                      job.media.map((url, index) => (
+                        <div
+                          key={index}
+                          className="aspect-video bg-gray-100 rounded-lg overflow-hidden cursor-pointer hover:opacity-90 transition-opacity group relative border border-gray-100"
+                          onClick={() => setSelectedImageIndex(index)}
+                        >
+                          <img
+                            src={url}
+                            alt={`Job media ${index + 1}`}
+                            className="w-full h-full object-cover"
+                          />
+                          <div className="absolute inset-0 bg-blue-600/0 group-hover:bg-blue-600/10 transition-all flex items-center justify-center">
+                            <ExternalLink className="text-white opacity-0 group-hover:opacity-100 transition-opacity h-5 w-5" />
+                          </div>
                         </div>
+                      ))
+                    ) : (
+                      <div className="col-span-2 text-center py-4 text-[9px] font-bold text-gray-300 uppercase tracking-widest">
+                        No attachments
                       </div>
-                    ))
-                  ) : (
-                    <div className="col-span-2 text-center py-4 text-sm text-gray-500">
-                      No media attachments
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-
-            <div className="border-t border-gray-300 mb-6 mt-6 -mx-6" />
-
-            <div>
-              <button
-                onClick={() => setShowApplicants(!showApplicants)}
-                className="w-full flex items-center justify-between text-base font-semibold text-gray-900 mb-3 hover:text-gray-700 transition-colors"
-              >
-                <span>Applicants ({applicants.length})</span>
-                {showApplicants ? (
-                  <ChevronUp className="h-5 w-5" />
-                ) : (
-                  <ChevronDown className="h-5 w-5" />
+                    )}
+                  </div>
                 )}
-              </button>
+              </div>
 
-              {showApplicants && (
-                <div className="mt-3">
-                  {loadingApplicants ? (
-                    <div className="text-center py-4">
-                      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
-                    </div>
-                  ) : applicants.length > 0 ? (
-                    <div className="space-y-3">
+              <div className="h-px bg-gray-50" />
+
+              <div className="overflow-hidden">
+                <button
+                  onClick={() => setShowApplicants(!showApplicants)}
+                  className={`w-full flex items-center justify-between py-2 text-[10px] font-black text-gray-400 hover:text-emerald-500 uppercase tracking-[0.2em] transition-colors`}
+                >
+                  <div className="flex items-center gap-2">
+                    <Users className="h-3 w-3" />
+                    <span>Applicants ({applicants.length})</span>
+                  </div>
+                  <ChevronDown className={`h-3 w-3 transition-transform duration-300 ${showApplicants ? 'rotate-180' : ''}`} />
+                </button>
+
+                {showApplicants && (
+                  <div className="mt-4">
+                    {loadingApplicants ? (
+                      <div className="text-center py-4">
+                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+                      </div>
+                    ) : applicants.length > 0 ? (
+                      <div className="space-y-3">
                       {applicants.map((application) => (
                         <div
                           key={application._id}
@@ -445,29 +506,30 @@ const JobDetailsModal: React.FC<JobDetailsModalProps> = ({
             </div>
           </div>
         </div>
+      </div>
 
-        <div className="border-t border-gray-300 p-6 bg-gray-50">
+      <div className="border-t border-gray-100 p-6 bg-white flex-shrink-0">
           <div className="flex gap-3">
             {job.archived && job.archiveType === 'removed' ? (
               <button
                 onClick={handleRestoreJob}
-                className="flex-1 px-4 py-3 border border-green-300 rounded-lg text-sm font-medium text-green-700 bg-white hover:bg-green-50 transition-colors flex items-center justify-center gap-2"
+                className="flex-1 px-4 py-3.5 bg-emerald-600 text-white rounded-xl text-xs font-black uppercase tracking-widest hover:bg-emerald-700 shadow-md shadow-emerald-100 transition-all active:scale-[0.98] flex items-center justify-center gap-2"
               >
                 <RotateCcw className="h-4 w-4" />
-                Restore
+                Restore Job
               </button>
             ) : job.archived && job.archiveType === 'hidden' ? (
               <>
                 <button
                   onClick={handleUnhideJob}
-                  className="flex-1 px-4 py-3 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
+                  className="flex-1 px-4 py-3.5 bg-blue-600 text-white rounded-xl text-xs font-black uppercase tracking-widest hover:bg-blue-700 shadow-md shadow-blue-100 transition-all active:scale-[0.98] flex items-center justify-center gap-2"
                 >
                   <Eye className="h-4 w-4" />
                   Unhide
                 </button>
                 <button
                   onClick={handleDeleteJob}
-                  className="flex-1 px-4 py-3 border border-red-300 rounded-lg text-sm font-medium text-red-700 bg-white hover:bg-red-50 transition-colors flex items-center justify-center gap-2"
+                  className="flex-1 px-4 py-3.5 bg-red-600 text-white rounded-xl text-xs font-black uppercase tracking-widest hover:bg-red-700 shadow-md shadow-red-100 transition-all active:scale-[0.98] flex items-center justify-center gap-2"
                 >
                   <Trash2 className="h-4 w-4" />
                   Delete
@@ -478,7 +540,7 @@ const JobDetailsModal: React.FC<JobDetailsModalProps> = ({
                 {job.isHidden ? (
                   <button
                     onClick={handleUnhideJob}
-                    className="flex-1 px-4 py-3 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
+                    className="flex-1 px-4 py-3.5 bg-blue-600 text-white rounded-xl text-xs font-black uppercase tracking-widest hover:bg-blue-700 shadow-md shadow-blue-100 transition-all active:scale-[0.98] flex items-center justify-center gap-2"
                   >
                     <Eye className="h-4 w-4" />
                     Unhide
@@ -486,15 +548,15 @@ const JobDetailsModal: React.FC<JobDetailsModalProps> = ({
                 ) : (
                   <button
                     onClick={handleHideJob}
-                    className="flex-1 px-4 py-3 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
+                    className="flex-1 px-4 py-3.5 bg-gray-900 text-white rounded-xl text-xs font-black uppercase tracking-widest hover:bg-gray-800 shadow-md shadow-gray-200 transition-all active:scale-[0.98] flex items-center justify-center gap-2"
                   >
                     <EyeOff className="h-4 w-4" />
-                    Hide
+                    Hide Job
                   </button>
                 )}
                 <button
                   onClick={handleDeleteJob}
-                  className="flex-1 px-4 py-3 border border-red-300 rounded-lg text-sm font-medium text-red-700 bg-white hover:bg-red-50 transition-colors flex items-center justify-center gap-2"
+                  className="flex-1 px-4 py-3.5 bg-white border border-red-200 text-red-600 rounded-xl text-xs font-black uppercase tracking-widest hover:bg-red-50 transition-all active:scale-[0.98] flex items-center justify-center gap-2"
                 >
                   <Trash2 className="h-4 w-4" />
                   Delete
@@ -567,7 +629,8 @@ const JobDetailsModal: React.FC<JobDetailsModalProps> = ({
           </div>
         </>
       )}
-    </>
+    </>,
+    document.body
   );
 };
 

--- a/Frontend/src/components/Modals/TransactionDetailsModal.tsx
+++ b/Frontend/src/components/Modals/TransactionDetailsModal.tsx
@@ -7,6 +7,7 @@ import { getInitials, formatPHPCurrency, getUser, getToUser } from '../../utils'
 import { transactionsService } from '../../services';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
+import { SidebarContext } from '../Layout/Layout';
 
 interface TransactionDetailsModalProps {
   isOpen: boolean;
@@ -21,6 +22,19 @@ const TransactionDetailsModal: React.FC<TransactionDetailsModalProps> = ({
   transaction,
   onStatusUpdate
 }) => {
+  const { setIsHeaderHidden } = React.useContext(SidebarContext);
+
+  React.useEffect(() => {
+    if (setIsHeaderHidden) {
+      setIsHeaderHidden(isOpen);
+    }
+    return () => {
+      if (setIsHeaderHidden) {
+        setIsHeaderHidden(false);
+      }
+    };
+  }, [isOpen, setIsHeaderHidden]);
+
   if (!isOpen || !transaction) return null;
 
   const formatCurrency = (amount: number) => {

--- a/Frontend/src/components/Modals/UserDetailsModal.tsx
+++ b/Frontend/src/components/Modals/UserDetailsModal.tsx
@@ -16,9 +16,10 @@ import type {
   Verification,
   PenaltyData
 } from '../../types';
-import VerificationStatusBadge from '../UI/VerificationStatusBadge';
 import UserTypeBadge from '../UI/UserTypeBadge';
+import VerificationStatusBadge from '../UI/VerificationStatusBadge';
 import toast from 'react-hot-toast';
+import { SidebarContext } from '../Layout/Layout';
 
 const getInitials = (name: string): string => {
   const nameParts = name.trim().split(' ').filter(part => part.length > 0);
@@ -57,6 +58,18 @@ const UserDetailsModal: React.FC<UserDetailsModalProps> = ({
   const [restrictionTimer, setRestrictionTimer] = useState<string | null>(null);
   const [_restrictedByAdmin, setRestrictedByAdmin] = useState<{ _id: string; name: string } | null>(null);
   const [_loadingRestrictedBy, setLoadingRestrictedBy] = useState(false);
+  const { setIsHeaderHidden } = React.useContext(SidebarContext);
+
+  useEffect(() => {
+    if (setIsHeaderHidden) {
+      setIsHeaderHidden(isOpen);
+    }
+    return () => {
+      if (setIsHeaderHidden) {
+        setIsHeaderHidden(false);
+      }
+    };
+  }, [isOpen, setIsHeaderHidden]);
 
   // Calculate remaining restriction time
   useEffect(() => {

--- a/Frontend/src/components/Modals/VerificationDetailsModal.tsx
+++ b/Frontend/src/components/Modals/VerificationDetailsModal.tsx
@@ -9,9 +9,9 @@ import {
 import toast from 'react-hot-toast';
 import verificationsService from '../../services/verificationsService';
 import ClickableImage from '../UI/ClickableImage';
-import UserTypeBadge from '../UI/UserTypeBadge';
 import VerificationStatusBadge from '../UI/VerificationStatusBadge';
 import type { Verification, UserInfo } from '../../types';
+import { SidebarContext } from '../Layout/Layout';
 
 const getInitials = (name: string): string => {
   const nameParts = name.trim().split(' ').filter(part => part.length > 0);
@@ -90,6 +90,19 @@ const VerificationDetailsModal: React.FC<VerificationDetailsModalProps> = ({
   const [attemptCache, setAttemptCache] = useState<Record<number, { images: any; submittedAt: string | null }>>({});
   const [attemptTimestamps, setAttemptTimestamps] = useState<{ attempt: number; submittedAt: string | Date | null }[] | null>(null);
   const [currentAttemptSubmittedAt, setCurrentAttemptSubmittedAt] = useState<string | Date | null>(null);
+  const { setIsHeaderHidden } = React.useContext(SidebarContext);
+
+  useEffect(() => {
+    if (setIsHeaderHidden) {
+      setIsHeaderHidden(isOpen);
+    }
+    return () => {
+      if (setIsHeaderHidden) {
+        setIsHeaderHidden(false);
+      }
+    };
+  }, [isOpen, setIsHeaderHidden]);
+
   const prevVerificationId = useRef<string | null>(null);
 
   // Dragging refs

--- a/Frontend/src/components/Settings/CreateAdminModal.tsx
+++ b/Frontend/src/components/Settings/CreateAdminModal.tsx
@@ -146,9 +146,9 @@ const CreateAdminModal: React.FC<CreateAdminModalProps> = ({ isOpen, onClose, on
           dashboard: true,
           users: true,
           jobs: true,
-          transactions: false,
+          transactions: true,
           verifications: true,
-          support: false,
+          support: true,
           activity: true,
           flagged: true,
           settings: false
@@ -566,7 +566,7 @@ const CreateAdminModal: React.FC<CreateAdminModalProps> = ({ isOpen, onClose, on
                         </div>
                         <span className="text-sm font-semibold text-gray-900">Admin</span>
                       </div>
-                      <p className="text-xs text-gray-600">Dashboard, Users, Jobs, Verifications, Activity, Flagged</p>
+                      <p className="text-xs text-gray-600">All access except system settings</p>
                     </button>
 
                     <button

--- a/Frontend/src/components/Settings/EditAdminModal.tsx
+++ b/Frontend/src/components/Settings/EditAdminModal.tsx
@@ -641,9 +641,9 @@ const EditAdminModal: React.FC<EditAdminModalProps> = ({ isOpen, onClose, onSucc
                               dashboard: true,
                               users: true,
                               jobs: true,
-                              transactions: false,
+                              transactions: true,
                               verifications: true,
-                              support: false,
+                              support: true,
                               activity: true,
                               flagged: true,
                               settings: false
@@ -653,9 +653,9 @@ const EditAdminModal: React.FC<EditAdminModalProps> = ({ isOpen, onClose, onSucc
                         className={`p-4 rounded-lg border-2 text-left transition-all ${formData.permissions.dashboard === true &&
                           formData.permissions.users === true &&
                           formData.permissions.jobs === true &&
-                          formData.permissions.transactions === false &&
+                          formData.permissions.transactions === true &&
                           formData.permissions.verifications === true &&
-                          formData.permissions.support === false &&
+                          formData.permissions.support === true &&
                           formData.permissions.activity === true &&
                           formData.permissions.flagged === true &&
                           formData.permissions.settings === false
@@ -671,7 +671,7 @@ const EditAdminModal: React.FC<EditAdminModalProps> = ({ isOpen, onClose, onSucc
                           </div>
                           <span className="text-sm font-semibold text-gray-900">Admin</span>
                         </div>
-                        <p className="text-xs text-gray-600">Dashboard, Users, Jobs, Verifications, Activity, Flagged</p>
+                        <p className="text-xs text-gray-600">All access except system settings</p>
                       </button>
 
                       <button

--- a/Frontend/src/hooks/useTransactions.ts
+++ b/Frontend/src/hooks/useTransactions.ts
@@ -40,10 +40,16 @@ export const useTransactionCounts = (type?: string) => {
 
       return {
         total: totalData.pagination?.total || 0,
+        totalAmount: totalData.stats?.totalAmount || 0,
         pending: pendingData.pagination?.total || 0,
+        pendingAmount: pendingData.stats?.totalAmount || 0,
         completed: completedData.pagination?.total || 0,
+        completedAmount: completedData.stats?.totalAmount || 0,
+        completedRevenue: completedData.stats?.totalAmount || 0, // for backward compatibility/clarity
         failed: failedData.pagination?.total || 0,
-        cancelled: cancelledData.pagination?.total || 0
+        failedAmount: failedData.stats?.totalAmount || 0,
+        cancelled: cancelledData.pagination?.total || 0,
+        cancelledAmount: cancelledData.stats?.totalAmount || 0
       };
     },
     staleTime: 5 * 60 * 1000,
@@ -59,8 +65,8 @@ export const useTransactionMutations = () => {
   };
 
   const updateTransactionStatus = useMutation({
-    mutationFn: ({ transactionId, status }: { transactionId: string; status: string }) =>
-      transactionsService.updateTransactionStatus(transactionId, status),
+    mutationFn: ({ transactionId, status, type }: { transactionId: string; status: any; type: string }) =>
+      transactionsService.updateTransactionStatus(transactionId, { status, type }),
     onSuccess: () => {
       invalidateTransactions();
       toast.success('Transaction status updated successfully');

--- a/Frontend/src/pages/Activity.tsx
+++ b/Frontend/src/pages/Activity.tsx
@@ -14,7 +14,8 @@ import {
   Calendar,
   Activity as ActivityIcon,
   MousePointerClick,
-  Briefcase
+  Briefcase,
+  Filter as FilterIcon
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import toast from 'react-hot-toast';
@@ -23,6 +24,7 @@ import { UserDetailsModal, TransactionDetailsModal } from '../components/Modals'
 import { getInitials } from '../utils';
 import { useActivityLogs } from '../hooks';
 import { useSocket } from '../context/SocketContext';
+import StatsCard from '../components/Dashboard/StatsCard';
 import type { User, Transaction } from '../types';
 
 interface AdminInfo {
@@ -408,151 +410,139 @@ const Activity: React.FC = () => {
   }, [pagination.page, highlightedActivityId, searchParams, setSearchParams, activities, handleActivityClick]);
 
   return (
-    <div className="fixed inset-0 md:left-72 flex flex-col bg-gray-50 mt-16 md:mt-0">
-      <div className="flex-shrink-0 bg-white px-4 md:px-6 py-4 md:py-5 border-b border-gray-200">
-        <div className="hidden md:flex flex-col md:flex-row md:items-center md:justify-between mb-4 gap-3">
-          <div>
-            <h1 className="text-xl md:text-2xl font-bold text-gray-900">Activity Logs</h1>
-            <p className="text-xs md:text-sm text-gray-500 mt-1">
-              Track and monitor all administrative actions and system events across the platform
-            </p>
+    <div className="fixed inset-0 md:left-72 flex flex-col bg-gray-50 mt-16 md:mt-0 h-screen overflow-hidden text-gray-700">
+      <div className="flex-shrink-0 bg-white border-b border-gray-200 z-30 shadow-sm relative">
+        <div className="px-6 py-5">
+          <div className="flex items-center justify-between mb-6">
+            <div>
+              <div className="flex items-center gap-2 mb-1">
+                <span className="p-1.5 bg-blue-50 rounded-lg">
+                  <ActivityIcon className="h-5 w-5 text-blue-600" />
+                </span>
+                <h1 className="text-2xl font-black text-gray-900 tracking-tight">
+                  Activity Center
+                </h1>
+              </div>
+              <p className="text-xs text-gray-500 font-medium">
+                Track and monitor all administrative actions and system events across the platform
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <div className="cursor-pointer" onClick={() => setTypeFilter('all')}>
+              <StatsCard
+                title="Total Activity"
+                value={totalActivityLogs.toString()}
+                icon={ActivityIcon}
+                color="blue"
+                variant="tinted"
+                isActive={typeFilter === 'all'}
+                smallIcon={true}
+              />
+            </div>
+            <div className="cursor-pointer" onClick={() => setTypeFilter('user')}>
+              <StatsCard
+                title="User Actions"
+                value={userActivityLogs.toString()}
+                icon={UserCheck}
+                color="purple"
+                variant="tinted"
+                isActive={typeFilter === 'user'}
+                smallIcon={true}
+              />
+            </div>
+            <div className="cursor-pointer" onClick={() => setTypeFilter('job')}>
+              <StatsCard
+                title="Job Actions"
+                value={activities.filter((activity: ActivityLog) => JOB_ACTIONS.includes(activity.actionType)).length.toString()}
+                icon={Briefcase}
+                color="orange"
+                variant="tinted"
+                isActive={typeFilter === 'job'}
+                smallIcon={true}
+              />
+            </div>
+            <div className="cursor-pointer" onClick={() => setTypeFilter('system')}>
+              <StatsCard
+                title="System Actions"
+                value={systemActivityLogs.toString()}
+                icon={Shield}
+                color="green"
+                variant="tinted"
+                isActive={typeFilter === 'system'}
+                smallIcon={true}
+              />
+            </div>
           </div>
         </div>
 
-        {/* Mobile: Compact Grid */}
-        <div className="grid grid-cols-2 gap-2 md:hidden mb-4">
-          <div
-            onClick={() => setTypeFilter('all')}
-            className={`rounded-lg p-2.5 border cursor-pointer transition-all flex items-center justify-between bg-blue-50 border-blue-200 ${typeFilter === 'all' ? 'border-blue-400 ring-2 ring-blue-300' : ''
-              }`}
-          >
-            <div className="flex items-center gap-2">
-              <ActivityIcon className="h-4 w-4 text-blue-600" />
-              <span className="text-sm font-medium text-gray-700">Total</span>
-            </div>
-            <span className="text-sm font-bold text-blue-700">{totalActivityLogs}</span>
-          </div>
-
-          <div
-            onClick={() => setTypeFilter('user')}
-            className={`rounded-lg p-2.5 border cursor-pointer transition-all flex items-center justify-between bg-purple-50 border-purple-200 ${typeFilter === 'user' ? 'border-purple-400 ring-2 ring-purple-300' : ''
-              }`}
-          >
-            <div className="flex items-center gap-2">
-              <UserCheck className="h-4 w-4 text-purple-600" />
-              <span className="text-sm font-medium text-gray-700">User</span>
-            </div>
-            <span className="text-sm font-bold text-purple-700">{userActivityLogs}</span>
-          </div>
-
-          <div
-            onClick={() => setTypeFilter('job')}
-            className={`rounded-lg p-2.5 border cursor-pointer transition-all flex items-center justify-between bg-orange-50 border-orange-200 ${typeFilter === 'job' ? 'border-orange-400 ring-2 ring-orange-300' : ''
-              }`}
-          >
-            <div className="flex items-center gap-2">
-              <Briefcase className="h-4 w-4 text-orange-600" />
-              <span className="text-sm font-medium text-gray-700">Job</span>
-            </div>
-            <span className="text-sm font-bold text-orange-700">{activities.filter((activity: ActivityLog) => JOB_ACTIONS.includes(activity.actionType)).length}</span>
-          </div>
-
-          <div
-            onClick={() => setTypeFilter('system')}
-            className={`rounded-lg p-2.5 border cursor-pointer transition-all flex items-center justify-between bg-green-50 border-green-200 ${typeFilter === 'system' ? 'border-green-400 ring-2 ring-green-300' : ''
-              }`}
-          >
-            <div className="flex items-center gap-2">
-              <Shield className="h-4 w-4 text-green-600" />
-              <span className="text-sm font-medium text-gray-700">System</span>
-            </div>
-            <span className="text-sm font-bold text-green-700">{systemActivityLogs}</span>
-          </div>
-        </div>
-
-        {/* Desktop: Full Grid */}
-        <div className="hidden md:grid grid-cols-4 gap-3 mb-4">
-          <div
-            onClick={() => setTypeFilter('all')}
-            className={`bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg p-3 border cursor-pointer hover:shadow-lg transition-all ${typeFilter === 'all' ? 'border-blue-500 ring-2 ring-blue-400 shadow-lg' : 'border-blue-200'
-              }`}
-          >
-            <p className="text-xs text-gray-600 font-medium mb-1">Total Activity Logs</p>
-            <p className="text-xl md:text-2xl font-bold text-gray-900">{totalActivityLogs}</p>
-          </div>
-
-          <div
-            onClick={() => setTypeFilter('user')}
-            className={`bg-gradient-to-br from-purple-50 to-purple-100 rounded-lg p-3 border cursor-pointer hover:shadow-lg transition-all ${typeFilter === 'user' ? 'border-purple-500 ring-2 ring-purple-400 shadow-lg' : 'border-purple-200'
-              }`}
-          >
-            <p className="text-xs text-gray-600 font-medium mb-1">User Actions</p>
-            <p className="text-xl md:text-2xl font-bold text-gray-900">{userActivityLogs}</p>
-          </div>
-
-          <div
-            onClick={() => setTypeFilter('job')}
-            className={`bg-gradient-to-br from-orange-50 to-orange-100 rounded-lg p-3 border cursor-pointer hover:shadow-lg transition-all ${typeFilter === 'job' ? 'border-orange-500 ring-2 ring-orange-400 shadow-lg' : 'border-orange-200'
-              }`}
-          >
-            <p className="text-xs text-gray-600 font-medium mb-1">Job Actions</p>
-            <p className="text-xl md:text-2xl font-bold text-gray-900">{activities.filter((activity: ActivityLog) => JOB_ACTIONS.includes(activity.actionType)).length}</p>
-          </div>
-
-          <div
-            onClick={() => setTypeFilter('system')}
-            className={`bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-3 border cursor-pointer hover:shadow-lg transition-all ${typeFilter === 'system' ? 'border-green-500 ring-2 ring-green-400 shadow-lg' : 'border-green-200'
-              }`}
-          >
-            <p className="text-xs text-gray-600 font-medium mb-1">System Actions</p>
-            <p className="text-xl md:text-2xl font-bold text-gray-900">{systemActivityLogs}</p>
-          </div>
-        </div>
-
-        <div className="flex flex-col md:flex-row gap-3">
+        <div className="px-4 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
           <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 h-4 md:h-5 w-4 md:w-5" />
+            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
             <input
               type="text"
               placeholder="Search by admin, description, or target..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-9 md:pl-10 pr-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
+              className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm"
             />
           </div>
 
-          <select
-            value={actionFilter}
-            onChange={(e) => setActionFilter(e.target.value)}
-            className="px-3 md:px-4 py-2 bg-white border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm font-medium"
-          >
-            <option value="all">All Actions</option>
-            <option value="verification_approved">Verification Approved</option>
-            <option value="verification_rejected">Verification Rejected</option>
-            <option value="user_restricted">User Restricted</option>
-            <option value="user_suspended">User Suspended</option>
-            <option value="user_banned">User Banned</option>
-            <option value="user_unrestricted">User Unrestricted</option>
-            <option value="transaction_completed">Transaction Completed</option>
-            <option value="transaction_failed">Transaction Failed</option>
-            <option value="support_closed">Support Closed</option>
-            <option value="support_reopened">Support Reopened</option>
-            <option value="admin_login">Admin Login</option>
-            <option value="job_hidden">Job Hidden</option>
-            <option value="job_unhidden">Job Restored</option>
-            <option value="job_deleted">Job Deleted</option>
-            <option value="job_restored">Job Restored</option>
-          </select>
+          <div className="flex items-center gap-2 md:gap-4 overflow-x-auto no-scrollbar pb-0.5 md:pb-0 shrink-0">
+            <div className="flex items-center gap-2 bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm">
+              <FilterIcon className="h-4 w-4 text-gray-400" />
+              <select
+                value={actionFilter}
+                onChange={(e) => setActionFilter(e.target.value)}
+                className="bg-transparent border-none text-xs font-black text-gray-600 focus:outline-none focus:ring-0 cursor-pointer pr-8"
+              >
+                <option value="all">All Actions</option>
+                <option value="verification_approved">Verification Approved</option>
+                <option value="verification_rejected">Verification Rejected</option>
+                <option value="user_restricted">User Restricted</option>
+                <option value="user_suspended">User Suspended</option>
+                <option value="user_banned">User Banned</option>
+                <option value="user_unrestricted">User Unrestricted</option>
+                <option value="transaction_completed">Transaction Completed</option>
+                <option value="transaction_failed">Transaction Failed</option>
+                <option value="support_closed">Support Closed</option>
+                <option value="support_reopened">Support Reopened</option>
+                <option value="admin_login">Admin Login</option>
+                <option value="job_hidden">Job Hidden</option>
+                <option value="job_unhidden">Job Restored</option>
+                <option value="job_deleted">Job Deleted</option>
+                <option value="job_restored">Job Restored</option>
+              </select>
+            </div>
+
+            <div className="hidden md:flex items-center gap-2 md:order-3 shrink-0">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+              <select 
+                value={pagination.limit}
+                onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
+          </div>
         </div>
       </div>
 
       <div className="flex-1 overflow-hidden flex flex-col">
         <div className="flex-1 overflow-y-auto" ref={scrollContainerRef}>
           {loading ? (
-            <div className="flex items-center justify-center py-20">
-              <div className="text-center">
-                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-                <p className="text-gray-500">Loading activity logs...</p>
+            <div className="flex flex-col items-center justify-center py-20 gap-4">
+              <div className="relative">
+                <div className="h-16 w-16 rounded-full border-4 border-gray-100 border-t-blue-600 animate-spin" />
+                <ActivityIcon className="absolute inset-0 m-auto h-6 w-6 text-blue-600 animate-pulse" />
+              </div>
+              <div className="flex flex-col items-center italic">
+                <p className="text-sm font-black text-gray-900 tracking-widest uppercase">Loading Activity Logs</p>
+                <p className="text-[10px] text-gray-400 font-bold uppercase tracking-[0.2em] mt-1">Fetching System Events</p>
               </div>
             </div>
           ) : filteredActivities.length === 0 ? (
@@ -567,13 +557,13 @@ const Activity: React.FC = () => {
             <>
               <div className="hidden md:block bg-white">
                 <table className="min-w-full">
-                  <thead className="bg-gray-50 border-b border-gray-200 sticky top-0 z-10">
+                  <thead className="bg-gray-50/80 backdrop-blur-md sticky top-0 z-10 border-b-2 border-gray-300">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Admin</th>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Action</th>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Description</th>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Target</th>
-                      <th className="px-6 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Date</th>
+                      <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Admin</th>
+                      <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Action</th>
+                      <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Description</th>
+                      <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Target</th>
+                      <th className="px-6 py-4 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">Date</th>
                     </tr>
                   </thead>
                   <tbody className="bg-white border-b border-gray-300">
@@ -605,28 +595,28 @@ const Activity: React.FC = () => {
                             : ''
                           }`}
                       >
-                        <td className="px-6 py-4 whitespace-nowrap border-b border-gray-300">
-                          <div className="flex items-center">
-                            <div className="w-10 h-10 rounded-full bg-gray-300 flex items-center justify-center flex-shrink-0">
-                              <span className="text-sm font-semibold text-gray-700">
+                        <td className="px-6 py-2.5 whitespace-nowrap border-b border-gray-300">
+                          <div className="flex items-center gap-3">
+                            <div className="w-10 h-10 rounded-full bg-blue-50 flex items-center justify-center flex-shrink-0 border border-gray-100">
+                              <span className="text-sm font-bold text-blue-600 uppercase">
                                 {activity.adminId?.name ? getInitials(activity.adminId.name) : 'N/A'}
                               </span>
                             </div>
-                            <div className="ml-3">
+                            <div className="min-w-0">
                               <div className="flex items-center gap-2">
-                                <div className="text-sm font-semibold text-gray-900">{activity.adminId?.name || 'Unknown Admin'}</div>
+                                <div className="text-sm font-bold text-gray-900 truncate">{activity.adminId?.name || 'Unknown Admin'}</div>
                                 {activity.adminId?.userType === 'superadmin' && (
-                                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-purple-100 text-purple-700">
+                                  <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[9px] font-black uppercase tracking-widest bg-purple-50 text-purple-700 border border-purple-100 shadow-sm shadow-purple-50/50">
                                     Super Admin
                                   </span>
                                 )}
                               </div>
-                              <div className="text-xs text-gray-500 truncate max-w-[150px]">{activity.adminId?.email || 'No email'}</div>
+                              <div className="text-[10px] text-gray-400 font-bold uppercase tracking-wider">{activity.adminId?.email || 'No email'}</div>
                             </div>
                           </div>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap border-b border-gray-300">
-                          <span className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold ${ACTION_COLORS[activity.actionType] || 'bg-gray-100 text-gray-700'
+                          <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[9px] font-black uppercase tracking-widest border border-current shadow-sm ${ACTION_COLORS[activity.actionType] || 'bg-gray-50 text-gray-700 border-gray-200'
                             }`}>
                             {ACTION_ICONS[activity.actionType] || <ActivityIcon className="h-4 w-4" />}
                             {ACTION_LABELS[activity.actionType] || activity.actionType}
@@ -702,31 +692,31 @@ const Activity: React.FC = () => {
                       }
                     }}
                     onClick={() => handleActivityClick(activity)}
-                    className={`relative bg-white rounded-lg border border-gray-200 p-4 transition-all duration-200 ${activity.targetId && activity.targetType
-                      ? 'hover:bg-gray-100 cursor-pointer'
-                      : 'hover:bg-gray-50'
+                    className={`relative bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden active:scale-[0.98] transition-all p-4 ${activity.targetId && activity.targetType
+                      ? 'cursor-pointer'
+                      : ''
                       } ${highlightedActivityId === activity._id
-                        ? 'bg-yellow-100 ring-2 ring-yellow-400'
+                        ? 'ring-2 ring-yellow-400 bg-yellow-50'
                         : ''
                       }`}
                   >
                     {activity.adminId?.userType === 'superadmin' && (
-                      <span className="absolute top-4 right-4 inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold bg-purple-100 text-purple-700">
+                      <span className="absolute top-4 right-4 inline-flex items-center px-1.5 py-0.5 rounded-full text-[9px] font-black uppercase tracking-widest bg-purple-50 text-purple-700 border border-purple-100 shadow-sm shadow-purple-50/50">
                         Super Admin
                       </span>
                     )}
 
                     <div className="flex items-center gap-3 mb-3 pr-20"> {/* Added padding for absolute badge */}
-                      <div className="w-12 h-12 rounded-full bg-gray-300 flex items-center justify-center flex-shrink-0">
-                        <span className="text-base font-semibold text-gray-700">
+                      <div className="w-12 h-12 rounded-full bg-blue-50 flex items-center justify-center flex-shrink-0 border border-gray-100 shadow-sm">
+                        <span className="text-base font-bold text-blue-600 uppercase">
                           {activity.adminId?.name ? getInitials(activity.adminId.name) : 'N/A'}
                         </span>
                       </div>
                       <div className="flex-1 min-w-0">
                         <div className="flex items-center gap-2">
-                          <h3 className="text-sm font-semibold text-gray-900 truncate">{activity.adminId?.name || 'Unknown Admin'}</h3>
+                          <h3 className="text-sm font-black text-gray-900 truncate">{activity.adminId?.name || 'Unknown Admin'}</h3>
                         </div>
-                        <p className="text-xs text-gray-500 truncate">{activity.adminId?.email || 'No email'}</p>
+                        <p className="text-[10px] text-gray-500 font-bold uppercase tracking-wider truncate">{activity.adminId?.email || 'No email'}</p>
                       </div>
                     </div>
 
@@ -738,7 +728,7 @@ const Activity: React.FC = () => {
                       return (
                         <>
                           <div className="mb-3">
-                            <span className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold ${ACTION_COLORS[activity.actionType] || 'bg-gray-100 text-gray-700'
+                            <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[9px] font-black uppercase tracking-widest border border-current shadow-sm ${ACTION_COLORS[activity.actionType] || 'bg-gray-50 text-gray-700 border-gray-200'
                               }`}>
                               {ACTION_ICONS[activity.actionType] || <ActivityIcon className="h-4 w-4" />}
                               {ACTION_LABELS[activity.actionType] || activity.actionType}
@@ -749,7 +739,7 @@ const Activity: React.FC = () => {
 
                           {(activity.targetId || showTransactionTarget) && (
                             <div className="mb-3 pb-3 border-b border-gray-100">
-                              <p className="text-xs text-gray-500 mb-1">Target:</p>
+                              <p className="text-[9px] text-gray-400 font-black uppercase tracking-widest mb-1">Target</p>
                               <div className="flex items-center justify-between gap-2 mb-1">
                                 <p className="text-sm font-medium text-gray-900 truncate flex items-center gap-2 flex-1">
                                   {typeof activity.targetId === 'object' && activity.targetId !== null ? (

--- a/Frontend/src/pages/ArchivedJobs.tsx
+++ b/Frontend/src/pages/ArchivedJobs.tsx
@@ -8,9 +8,12 @@ import {
   XCircle,
   MapPin,
   Calendar,
-  RefreshCw,
   ChevronRight,
   ShieldAlert,
+  Clock,
+  Users,
+  LayoutGrid,
+  Table2,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 
@@ -54,18 +57,19 @@ const ArchivedJobs: React.FC = () => {
     total: 0,
     pages: 0
   });
-  
+
   const [categories, setCategories] = useState<JobCategory[]>([]);
   const [professionsList, setProfessionsList] = useState<string[]>([]);
   const [iconTimestamp, setIconTimestamp] = useState(Date.now());
+  const [mobileViewType, setMobileViewType] = useState<'card' | 'table'>('card');
 
   // Resolver logic adapted from Dashboard.tsx for icons parity
   const resolveIconForJob = useMemo(() => (jobCategory: string, jobIcon?: string) => {
     if (!jobCategory) return { imagePath: '/assets/icons/categories/professional-services.png', label: 'General Service' };
-    
+
     // If a direct icon path or URL is provided, use it
     if (jobIcon && (jobIcon.startsWith('http') || jobIcon.includes('.'))) {
-      return { 
+      return {
         imagePath: jobIcon.startsWith('http') ? jobIcon : `/assets/icons/professions/${jobIcon}`,
         label: jobCategory
       };
@@ -225,11 +229,11 @@ const ArchivedJobs: React.FC = () => {
   };
 
   return (
-    <div className="fixed inset-0 md:left-72 flex flex-col bg-gray-50 mt-16 md:mt-0 h-screen overflow-hidden">
+    <div className="fixed top-16 md:top-0 bottom-0 left-0 md:left-72 right-0 flex flex-col bg-gray-50 overflow-hidden">
       {/* Header Section */}
       <div className="flex-shrink-0 bg-white border-b border-gray-200 z-30 shadow-sm relative">
         <div className="px-6 py-5">
-          <div className="flex items-center justify-between mb-6">
+          <div className="hidden md:flex items-center justify-between mb-6">
             <div>
               <div className="flex items-center gap-2 mb-1">
                 <span className="p-1.5 bg-gray-100 rounded-lg">
@@ -243,21 +247,15 @@ const ArchivedJobs: React.FC = () => {
                 View and manage job listings that have been hidden or removed
               </p>
             </div>
-            
-            <button 
-              onClick={() => queryClient.invalidateQueries({ queryKey: ['jobs'] })}
-              className="flex items-center gap-1.5 text-gray-600 hover:text-gray-900 font-bold bg-gray-50 border border-gray-200 px-3 py-2 rounded-lg transition-colors text-xs"
-            >
-              <RefreshCw className="h-4 w-4" />
-              <span>REFRESH DATA</span>
-            </button>
+
+
           </div>
 
           {/* Stats Cards Grid */}
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-            <div className="cursor-pointer" onClick={() => setArchiveTypeFilter('all')}>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3 md:gap-4">
+            <div className="cursor-pointer transition-transform active:scale-95" onClick={() => setArchiveTypeFilter('all')}>
               <StatsCard
-                title="Total Archived"
+                title="Total"
                 value={(archivedCounts.hidden + archivedCounts.removed).toLocaleString()}
                 icon={Archive}
                 color="blue"
@@ -266,9 +264,9 @@ const ArchivedJobs: React.FC = () => {
                 smallIcon={true}
               />
             </div>
-            <div className="cursor-pointer" onClick={() => setArchiveTypeFilter('hidden')}>
+            <div className="cursor-pointer transition-transform active:scale-95" onClick={() => setArchiveTypeFilter('hidden')}>
               <StatsCard
-                title="Hidden Jobs"
+                title="Hidden"
                 value={archivedCounts.hidden.toLocaleString()}
                 icon={Archive}
                 color="orange"
@@ -277,9 +275,9 @@ const ArchivedJobs: React.FC = () => {
                 smallIcon={true}
               />
             </div>
-            <div className="cursor-pointer" onClick={() => setArchiveTypeFilter('removed')}>
+            <div className="cursor-pointer transition-transform active:scale-95" onClick={() => setArchiveTypeFilter('removed')}>
               <StatsCard
-                title="Deleted Jobs"
+                title="Deleted"
                 value={archivedCounts.removed.toLocaleString()}
                 icon={XCircle}
                 color="red"
@@ -292,53 +290,77 @@ const ArchivedJobs: React.FC = () => {
         </div>
 
         {/* Filter Bar */}
-        <div className="px-6 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row items-center gap-4">
-          <div className="relative flex-1">
-            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
-            <input
-              type="text"
-              placeholder="Search by job title or description..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm"
-            />
-          </div>
+        <div className="px-4 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row md:items-center gap-3 md:gap-6">
+          {/* Row 1 on Mobile / Search on Desktop */}
+          <div className="flex items-center gap-2 md:contents">
+            <div className="relative flex-1 md:order-1">
+              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <input
+                type="text"
+                placeholder="Search archived jobs..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm h-10"
+              />
+            </div>
 
-          <div className="flex items-center gap-2">
-            <select
-              value={professionFilter}
-              onChange={(e) => setProfessionFilter(e.target.value)}
-              className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-bold text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
-            >
-              <option value="all">All Professions</option>
-              {professionsList.map(prof => (
-                <option key={prof} value={prof} className="capitalize">{prof}</option>
-              ))}
-            </select>
-
-            <select
-              value={statusFilter}
-              onChange={(e) => setStatusFilter(e.target.value)}
-              className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-bold text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
-            >
-              <option value="all">All Status</option>
-              <option value="open">Open</option>
-              <option value="in_progress">In Progress</option>
-              <option value="completed">Completed</option>
-              <option value="cancelled">Cancelled</option>
-            </select>
-
-            <div className="flex items-center gap-2 bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm">
-              <span className="text-xs font-bold text-gray-400">Limit:</span>
+            {/* Mobile-only Limit */}
+            <div className="flex md:hidden items-center gap-1.5 px-2">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
                 onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
-                className="bg-transparent text-xs font-bold text-gray-600 focus:outline-none"
+                className="bg-transparent border-none text-xs font-black text-gray-600 focus:outline-none focus:ring-0 cursor-pointer pr-8"
               >
                 <option value={10}>10</option>
                 <option value={20}>20</option>
                 <option value={50}>50</option>
               </select>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 md:flex-initial md:order-2 md:justify-end md:gap-6 shrink-0">
+            <div className="flex-1 md:flex-initial flex items-center gap-2 md:pb-0 overflow-hidden">
+              <select
+                value={professionFilter}
+                onChange={(e) => setProfessionFilter(e.target.value)}
+                className="flex-1 md:flex-initial bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-black uppercase tracking-wider text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 lg:min-w-[140px] md:max-w-[160px] truncate"
+              >
+                <option value="all">Professions</option>
+                {professionsList.map(prof => (
+                  <option key={prof} value={prof} className="capitalize">{prof}</option>
+                ))}
+              </select>
+            </div>
+
+            {/* Pagination Limit for Desktop */}
+            <div className="hidden md:flex items-center gap-2 md:order-3 shrink-0">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+              <select 
+                value={pagination.limit}
+                onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
+
+            {/* View Type Toggle - Mobile only */}
+            <div className="flex md:hidden items-center bg-white border border-gray-200 rounded-[12px] p-1 shadow-sm shrink-0 md:order-4">
+               <button
+                 onClick={() => setMobileViewType('card')}
+                 className={`p-1.5 rounded-[10px] transition-all ${mobileViewType === 'card' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+               >
+                 <LayoutGrid className="h-3.5 w-3.5" />
+               </button>
+               <button
+                 onClick={() => setMobileViewType('table')}
+                 className={`p-1.5 rounded-[10px] transition-all ${mobileViewType === 'table' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+               >
+                 <Table2 className="h-3.5 w-3.5" />
+               </button>
             </div>
           </div>
         </div>
@@ -365,7 +387,7 @@ const ArchivedJobs: React.FC = () => {
           ) : (
             <>
               {/* Desktop View */}
-              <div className="hidden lg:block bg-white flex-1 relative overflow-hidden">
+              <div className="hidden md:block bg-white flex-1 relative">
                 <table className="min-w-full table-fixed border-separate border-spacing-0">
                   <thead className="bg-gray-50/80 backdrop-blur-md sticky top-0 z-20">
                     <tr className="border-b border-gray-200">
@@ -398,7 +420,7 @@ const ArchivedJobs: React.FC = () => {
                           <td className="px-6 py-2 border-b border-gray-300">
                             <div className="flex items-center gap-4">
                               <div className="h-14 w-14 flex-shrink-0 flex items-center justify-center">
-                                <img 
+                                <img
                                   src={`${iconData.imagePath}?t=${iconTimestamp}`}
                                   alt={job.category}
                                   className="h-14 w-14 object-contain group-hover:scale-105 transition-transform"
@@ -419,7 +441,7 @@ const ArchivedJobs: React.FC = () => {
                           <td className="px-6 py-4 border-b border-gray-300">
                             <div className="flex items-center gap-3">
                               <div className="h-8 w-8 rounded-full bg-gray-100 flex items-center justify-center border border-gray-200 flex-shrink-0">
-                                 <span className="text-[10px] font-bold text-gray-500">{getInitials(job.user?.name || 'U')}</span>
+                                <span className="text-[10px] font-bold text-gray-500">{getInitials(job.user?.name || 'U')}</span>
                               </div>
                               <div className="min-w-0">
                                 <p className="text-xs font-bold text-gray-900 truncate">{job.user?.name || 'Anonymous'}</p>
@@ -427,132 +449,203 @@ const ArchivedJobs: React.FC = () => {
                               </div>
                             </div>
                           </td>
-                        <td className="px-6 py-4 text-center border-b border-gray-300">
-                          <span className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-wider border ${getJobStatusColor(job.status)}`}>
-                            {getJobStatusIcon(job.status)}
-                            {job.status.replace('_', ' ')}
-                          </span>
-                        </td>
-                        <td className="px-6 py-4 border-b border-gray-300">
-                          <div className="flex flex-col items-center">
-                            {job.archiveType === 'hidden' ? (
-                              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-wider bg-orange-50 text-orange-600 border border-orange-100">
-                                <Archive className="h-2.5 w-2.5" />
-                                Hidden
-                              </span>
-                            ) : (
-                              <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-wider bg-red-50 text-red-600 border border-red-100">
-                                <ShieldAlert className="h-2.5 w-2.5" />
-                                Deleted
-                              </span>
-                            )}
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 border-b border-gray-300">
-                          <div className="flex flex-col">
-                            <p className="text-xs font-bold text-gray-900">
-                              {job.archivedAt ? formatDistanceToNow(new Date(job.archivedAt), { addSuffix: true }) : 'N/A'}
-                            </p>
-                            <div className="flex items-center gap-1 text-[10px] font-medium text-gray-400 mt-1">
-                              <Calendar className="h-3 w-3" />
-                              {job.archivedAt ? new Date(job.archivedAt).toLocaleDateString() : 'N/A'}
+                          <td className="px-6 py-4 text-center border-b border-gray-300">
+                            <span className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-wider border ${getJobStatusColor(job.status)}`}>
+                              {getJobStatusIcon(job.status)}
+                              {job.status.replace('_', ' ')}
+                            </span>
+                          </td>
+                          <td className="px-6 py-4 border-b border-gray-300">
+                            <div className="flex flex-col items-center">
+                              {job.archiveType === 'hidden' ? (
+                                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-wider bg-orange-50 text-orange-600 border border-orange-100">
+                                  <Archive className="h-2.5 w-2.5" />
+                                  Hidden
+                                </span>
+                              ) : (
+                                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-wider bg-red-50 text-red-600 border border-red-100">
+                                  <ShieldAlert className="h-2.5 w-2.5" />
+                                  Deleted
+                                </span>
+                              )}
                             </div>
-                          </div>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
+                          </td>
+                          <td className="px-6 py-4 border-b border-gray-300">
+                            <div className="flex flex-col">
+                              <p className="text-xs font-bold text-gray-900">
+                                {job.archivedAt ? formatDistanceToNow(new Date(job.archivedAt), { addSuffix: true }) : 'N/A'}
+                              </p>
+                              <div className="flex items-center gap-1 text-[10px] font-medium text-gray-400 mt-1">
+                                <Calendar className="h-3 w-3" />
+                                {job.archivedAt ? new Date(job.archivedAt).toLocaleDateString() : 'N/A'}
+                              </div>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
                 </table>
               </div>
 
-              {/* Mobile Card View */}
-              <div className="lg:hidden flex-1 overflow-y-auto px-4 py-4 space-y-4">
-                {jobs.map((job) => {
-                  const iconData = resolveIconForJob(job.category, job.icon);
-                  return (
-                    <div
-                      key={job._id}
-                      onClick={() => openJobModal(job)}
-                      className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden active:scale-[0.98] transition-all"
-                    >
-                      <div className="flex items-center justify-between px-4 py-2.5 bg-gray-50/80 border-b border-gray-100">
-                        <div className="flex items-center gap-2">
-                           {job.archiveType === 'hidden' ? (
-                            <span className="px-2 py-0.5 rounded text-[9px] font-black uppercase tracking-widest bg-orange-100 text-orange-700">HIDDEN</span>
-                           ) : (
-                            <span className="px-2 py-0.5 rounded text-[9px] font-black uppercase tracking-widest bg-red-100 text-red-700">DELETED</span>
-                           )}
-                           <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[9px] font-black uppercase tracking-widest border ${getJobStatusColor(job.status)}`}>
-                             {job.status.replace('_', ' ')}
-                           </span>
-                        </div>
-                        <span className="text-[10px] font-bold text-gray-400 bg-white px-2 py-0.5 rounded border border-gray-100 uppercase tracking-widest font-mono">
-                          {job.archivedAt ? formatDistanceToNow(new Date(job.archivedAt), { addSuffix: true }) : 'N/A'}
-                        </span>
-                      </div>
-
-                      <div className="p-4">
-                         <div className="flex items-start gap-4 mb-4">
-                          <div className="h-12 w-12 rounded-xl bg-gray-50 border border-gray-100 flex items-center justify-center flex-shrink-0 overflow-hidden">
-                             <img 
-                               src={`${iconData.imagePath}?t=${iconTimestamp}`}
-                               alt={job.category}
-                               className="h-8 w-8 object-contain"
-                               onError={(e) => {
-                                 (e.target as HTMLImageElement).src = '/assets/icons/categories/professional-services.png';
-                                 (e.target as HTMLImageElement).onerror = null;
-                               }}
-                             />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <h3 className="text-base font-black text-gray-900 leading-tight mb-1 truncate">
-                              {job.title}
-                            </h3>
+              {/* Mobile Toggleable View */}
+              <div className="md:hidden flex-1 flex flex-col min-h-0 bg-white">
+                {mobileViewType === 'card' ? (
+                  <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+                    {jobs.map((job) => {
+                      const iconData = resolveIconForJob(job.category, job.icon);
+                      return (
+                        <div
+                          key={job._id}
+                          onClick={() => openJobModal(job)}
+                          className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden active:scale-[0.98] transition-all"
+                        >
+                          {/* Card Header: Status & Time */}
+                          <div className="flex items-center justify-between px-4 py-3 bg-gray-50/50 border-b border-gray-100">
                             <div className="flex items-center gap-2">
-                               <span className="text-[9px] font-black text-gray-400 uppercase tracking-widest bg-gray-50 px-2 py-0.5 rounded border border-gray-100">
-                                 {iconData.label || job.category || 'General Service'}
-                               </span>
+                              <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-wider border ${getJobStatusColor(job.status)} shadow-sm bg-white`}>
+                                {getJobStatusIcon(job.status)}
+                                {job.status.replace('_', ' ')}
+                              </span>
+                              {job.archiveType === 'hidden' ? (
+                                <span className="px-2 py-1 rounded-full text-[9px] font-black uppercase tracking-widest bg-orange-500 text-white shadow-sm ring-2 ring-orange-100">
+                                  HIDDEN
+                                </span>
+                              ) : (
+                                <span className="px-2 py-1 rounded-full text-[9px] font-black uppercase tracking-widest bg-red-500 text-white shadow-sm ring-2 ring-red-100">
+                                  DELETED
+                                </span>
+                              )}
+                            </div>
+                            <div className="flex items-center gap-1.5 text-[10px] font-bold text-gray-400">
+                              <Clock className="h-3 w-3" />
+                              {job.archivedAt ? formatDistanceToNow(new Date(job.archivedAt), { addSuffix: true }) : 'N/A'}
                             </div>
                           </div>
-                         </div>
 
-                       <div className="flex items-center gap-3 p-3 bg-gray-50/50 rounded-xl border border-gray-100 mb-4">
-                          <div className="h-8 w-8 rounded-full bg-white border border-gray-100 flex items-center justify-center flex-shrink-0 shadow-sm">
-                             <span className="text-[10px] font-black text-blue-600">{getInitials(job.user?.name || 'U')}</span>
-                          </div>
-                          <div className="min-w-0">
-                             <p className="text-xs font-black text-gray-900 truncate">{job.user?.name || 'Anonymous'}</p>
-                             <p className="text-[10px] text-gray-500 truncate">{job.user?.email || 'No email'}</p>
-                          </div>
-                       </div>
+                          {/* Card Content */}
+                          <div className="p-4">
+                            <div className="flex items-start gap-4 mb-4">
+                              <div className="relative flex-shrink-0">
+                                <div className="h-14 w-14 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center p-2 shadow-inner">
+                                  <img 
+                                    src={`${iconData.imagePath}?t=${iconTimestamp}`}
+                                    alt={job.category}
+                                    className="h-10 w-10 object-contain"
+                                    onError={(e) => {
+                                      (e.target as HTMLImageElement).src = '/assets/icons/categories/professional-services.png';
+                                      (e.target as HTMLImageElement).onerror = null;
+                                    }}
+                                  />
+                                </div>
+                              </div>
+                              <div className="flex-1 min-w-0">
+                                <h3 className="text-base font-black text-gray-900 leading-tight mb-1 truncate">
+                                  {job.title}
+                                </h3>
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <span className="text-[10px] font-black text-blue-600 uppercase tracking-widest bg-blue-50 px-2 py-0.5 rounded border border-blue-100">
+                                    {iconData.label || job.category || 'General Service'}
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
 
-                       <div className="grid grid-cols-2 gap-3 pt-4 border-t border-dashed border-gray-100">
-                          <div className="flex flex-col">
-                            <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest opacity-70">Job Budget</span>
-                            <span className="text-sm font-black text-gray-900">{formatCurrency(job.budget || 0)}</span>
+                            {/* Customer Info Snippet */}
+                            <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl border border-gray-100">
+                              <div className="h-8 w-8 rounded-full bg-white border border-gray-200 flex items-center justify-center text-[10px] font-black text-gray-500 shadow-sm">
+                                {getInitials(job.user?.name || 'U')}
+                              </div>
+                              <div className="min-w-0">
+                                <p className="text-xs font-bold text-gray-900 truncate">{job.user?.name || 'Anonymous'}</p>
+                                <p className="text-[10px] text-gray-400 truncate tracking-tight">{job.user?.email || 'No email'}</p>
+                              </div>
+                            </div>
+
+                            {/* Price & Location */}
+                            <div className="grid grid-cols-2 gap-4 mt-4 pt-4 border-t border-dashed border-gray-200">
+                              <div className="flex flex-col">
+                                <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest">Archived Price</span>
+                                <div className="flex items-baseline gap-1 mt-0.5">
+                                  <span className="text-lg font-black text-gray-900 leading-none">
+                                    {formatCurrency(job.budget || job.agreedPrice || 0)}
+                                  </span>
+                                  <span className="text-[9px] text-gray-400 font-bold uppercase">{job.paymentMethod || 'Wallet'}</span>
+                                </div>
+                              </div>
+                              <div className="flex flex-col items-end text-right">
+                                <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest">Location</span>
+                                <div className="flex items-center gap-1 text-[10px] font-bold text-gray-700 mt-1 max-w-full truncate">
+                                  <MapPin className="h-3 w-3 text-red-500" />
+                                  <span className="truncate">{job.locationDisplay || 'Remote'}</span>
+                                </div>
+                              </div>
+                            </div>
                           </div>
-                          <div className="flex flex-col items-end">
-                            <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest opacity-70">Payment</span>
-                            <span className="text-xs font-bold text-gray-900 uppercase tracking-widest">{job.paymentMethod}</span>
+
+                          {/* View Details Prompt */}
+                          <div className="px-4 py-2.5 bg-gray-50/30 border-t border-gray-100 flex items-center justify-center gap-1 text-[10px] font-black text-blue-600 uppercase tracking-widest">
+                            View Archived Details
+                            <ChevronRight className="h-3 w-3" />
                           </div>
-                       </div>
-                        <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-100/50">
-                          <div className="flex items-center gap-1.5 text-[9px] font-black text-gray-400 uppercase tracking-widest leading-none">
-                            <span className="w-1 h-1 bg-gray-300 rounded-full" />
-                            {job.locationDisplay || 'Remote / Not specified'}
-                          </div>
-                          <ChevronRight className="h-4 w-4 text-gray-300" />
                         </div>
-                      </div>
-                    </div>
-                  );
-                })}
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="flex-1 overflow-x-hidden">
+                    <table className="w-full table-fixed border-separate border-spacing-0">
+                      <thead className="bg-gray-50/80 sticky top-0 z-20">
+                        <tr>
+                          <th className="w-[55%] px-3 py-2.5 text-left text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Archived Job</th>
+                          <th className="w-[20%] px-2 py-2.5 text-center text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Type</th>
+                          <th className="w-[25%] px-3 py-2.5 text-right text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Date</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {jobs.map((job) => {
+                          const iconData = resolveIconForJob(job.category, job.icon);
+                          return (
+                            <tr 
+                              key={job._id} 
+                              onClick={() => openJobModal(job)}
+                              className="border-b border-gray-100 active:bg-gray-50 transition-colors"
+                            >
+                              <td className="px-3 py-3 overflow-hidden">
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <img 
+                                    src={`${iconData.imagePath}?t=${iconTimestamp}`} 
+                                    className="h-7 w-7 object-contain flex-shrink-0" 
+                                    alt="" 
+                                  />
+                                  <div className="min-w-0 flex-1">
+                                    <p className="text-[11px] font-black text-gray-900 truncate leading-tight">{job.title}</p>
+                                    <p className="text-[9px] text-gray-400 font-bold truncate uppercase">{job.user?.name}</p>
+                                  </div>
+                                </div>
+                              </td>
+                              <td className="px-2 py-3 text-center">
+                                <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[8px] font-black uppercase tracking-tight border ${job.archiveType === 'removed' ? 'border-red-200 text-red-600' : 'border-gray-200 text-gray-600'}`}>
+                                  {job.archiveType === 'removed' ? 'Del' : 'Hid'}
+                                </span>
+                              </td>
+                              <td className="px-3 py-3 text-right">
+                                <p className="text-[10px] font-black text-gray-900 leading-tight">
+                                  {job.archivedAt ? new Date(job.archivedAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: '2-digit' }) : 'N/A'}
+                                </p>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
               </div>
 
               {/* Pagination */}
               {pagination.pages > 1 && (
-                <div className="sticky bottom-0 flex bg-white border-t border-gray-200 shadow-lg z-10 p-4">
+                <div className="flex-shrink-0 bg-white border-t border-gray-200 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)] z-10 p-4 font-inter">
                   <div className="flex items-center justify-between w-full">
                     <div>
                       <p className="text-xs md:text-sm text-gray-700">
@@ -572,14 +665,14 @@ const ArchivedJobs: React.FC = () => {
                       <button
                         onClick={() => setPagination(prev => ({ ...prev, page: Math.max(1, prev.page - 1) }))}
                         disabled={pagination.page === 1}
-                        className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"
                       >
                         Previous
                       </button>
                       <button
                         onClick={() => setPagination(prev => ({ ...prev, page: Math.min(pagination.pages, prev.page + 1) }))}
                         disabled={pagination.page === pagination.pages}
-                        className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"
                       >
                         Next
                       </button>

--- a/Frontend/src/pages/Dashboard.tsx
+++ b/Frontend/src/pages/Dashboard.tsx
@@ -11,6 +11,8 @@ import { useSocket } from '../context/SocketContext';
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { useDashboardComparison, useDashboardRevenueChart, useDashboardPopularJobs } from '../hooks/useDashboard';
+import { useTransactionCounts } from '../hooks/useTransactions';
+import { useJobCounts } from '../hooks/useJobs';
 import { getProfessionIconByName } from '../constants/categoryIcons';
 import { settingsService } from '../services';
 import { JobCategory } from '../types/configuration.types';
@@ -27,13 +29,11 @@ function Header() {
       </div>
 
       <div className="hidden sm:flex items-center gap-3 bg-slate-50 border border-slate-100 hover:bg-slate-100 transition-colors cursor-pointer px-2.5 py-2 rounded-2xl shadow-sm">
-        <img
-          src={user?.profilePicture || "/src/assets/icons/Default_Icon.webp"}
-          alt="Admin Profile"
-          className="w-11 h-11 rounded-full object-cover border border-white shadow-sm bg-white"
-        />
+        <div className="w-11 h-11 rounded-full bg-blue-600 flex items-center justify-center border border-white shadow-sm text-white font-bold text-lg">
+          {user?.name ? user.name.charAt(0).toUpperCase() : 'A'}
+        </div>
         <div className="hidden sm:flex flex-col pr-3">
-          <span className="text-[15px] font-bold text-gray-900 leading-tight">{user?.firstName ? `${user.firstName} ${user.lastName}` : 'Admin User'}</span>
+          <span className="text-[15px] font-bold text-gray-900 leading-tight">{user?.name || 'Admin User'}</span>
           <span className="text-[13px] font-semibold text-gray-500 leading-tight mt-0.5">{user?.email || 'admin@company.com'}</span>
         </div>
       </div>
@@ -45,6 +45,8 @@ function StatCards() {
   const navigate = useNavigate();
   const { dashboardStats } = useSocket();
   const { data: comparison } = useDashboardComparison();
+  const { data: feeCounts } = useTransactionCounts('platform_fee');
+  const { data: jobCounts } = useJobCounts();
 
   const stats = dashboardStats || {
     totalRevenue: 0,
@@ -53,6 +55,8 @@ function StatCards() {
     activeJobs: 0,
     pendingFeesCount: 0
   };
+
+  const totalRevenueValue = jobCounts?.totalValue || 0;
 
   const formatCurrency = (value: number) => {
     return new Intl.NumberFormat('en-PH', {
@@ -68,7 +72,7 @@ function StatCards() {
     {
       icon: DollarSign,
       title: 'Total Revenue',
-      value: formatCurrency(stats.totalRevenue),
+      value: formatCurrency(totalRevenueValue),
       trend: comparison ? { value: comparison.revenue.percentage, isPositive: comparison.revenue.percentage >= 0 } : { value: 18.2, isPositive: true },
       color: 'green' as const,
       variant: 'solid' as const,
@@ -95,7 +99,7 @@ function StatCards() {
     {
       icon: AlertCircle,
       title: 'Pending Fees',
-      value: stats.pendingFeesCount?.toLocaleString() || '0',
+      value: feeCounts?.pending?.toLocaleString() || '0',
       trend: { value: 24.6, isPositive: true },
       color: 'red' as const,
       variant: 'default' as const,
@@ -105,13 +109,13 @@ function StatCards() {
 
   return (
     <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 mb-6">
-      {statCards.map((stat) => (
+      {statCards.map((stat, index) => (
         <div
           key={stat.title}
           onClick={stat.onClick}
           className="cursor-pointer"
         >
-          <StatsCard {...stat} />
+          <StatsCard {...stat} horizontalMobile={false} />
         </div>
       ))}
     </div>
@@ -127,14 +131,17 @@ function RevenueChart() {
     return rawChartData.map((d: any) => ({
       ...d,
       name: d.date || d._id,
-      revenue: d.totalAmount || d.revenue || 0
+      revenue: d.revenue || d.totalAmount || 0
     }));
   }, [rawChartData]);
 
+  const { data: jobCounts } = useJobCounts();
+
   const displayedTotalRevenue = useMemo(() => {
-    if (period === 'overall') return dashboardStats?.totalRevenue || 0;
+    // Standardize All Time revenue to 270k-based jobCounts
+    if (period === 'overall') return jobCounts?.totalValue || 0;
     return chartData.reduce((sum: number, item: any) => sum + (item.revenue || 0), 0);
-  }, [chartData, period, dashboardStats?.totalRevenue]);
+  }, [chartData, period, jobCounts?.totalValue]);
 
   return (
     <div className="bg-white p-5 rounded-2xl border border-gray-100 shadow-sm h-full flex flex-col">
@@ -637,10 +644,10 @@ function PopularJobsChart() {
             <p className="text-sm font-medium text-gray-500">No popular jobs found for this timeframe.</p>
           </div>
         ) : (
-          <div className="w-full h-full flex flex-row items-start justify-between relative px-1 sm:px-4 py-2">
+          <div className="w-full h-full flex flex-row items-center justify-between relative px-0 sm:px-4 py-2">
             {viewType === 'pie' && (
-              <div className="w-[55%] sm:w-1/2 h-full overflow-y-auto max-h-[300px] md:max-h-[400px] dashboard-scroll flex items-start justify-start pr-1 sm:pr-4 py-2">
-                <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 sm:gap-x-8 gap-y-2 sm:gap-y-4 m-0 p-0 w-full mt-1">
+              <div className="w-[58%] md:w-[65%] h-full overflow-y-auto max-h-[300px] md:max-h-[400px] dashboard-scroll flex items-center justify-start pr-1 sm:pr-4 py-2">
+                <ul className="grid grid-cols-1 md:grid-cols-2 gap-x-4 sm:gap-x-8 gap-y-2 sm:gap-y-4 m-0 p-0 w-full mt-1">
                   {chartData.map((entry: any, index: number) => {
                     const iconData = resolveIconData(entry, categories);
                     return (
@@ -665,12 +672,12 @@ function PopularJobsChart() {
               </div>
             )}
 
-            <div className={`h-full ${viewType === 'pie' ? 'w-1/2 min-h-[160px] sm:min-h-[220px]' : 'w-full pt-4'} relative flex-shrink-0`}>
+            <div className={`h-full ${viewType === 'pie' ? 'w-[42%] md:w-[35%] min-h-[160px] sm:min-h-[220px]' : 'w-full pt-4'} relative flex-shrink-0`}>
               {viewType === 'pie' ? (
                 <>
                   <div className="absolute inset-0 flex flex-col items-center justify-center pointer-events-none z-0">
-                    <span className="text-2xl sm:text-3xl font-bold text-gray-900 tracking-tight">₱{totalJobs.toLocaleString()}</span>
-                    <span className="text-[11px] sm:text-xs font-semibold text-emerald-600 mt-0.5">+12% ↑</span>
+                    <span className="text-xl sm:text-2xl font-bold text-gray-900 tracking-tight">₱{totalJobs.toLocaleString()}</span>
+                    <span className="text-[10px] sm:text-xs font-semibold text-emerald-600">Total</span>
                   </div>
                   <ResponsiveContainer width="100%" height="100%">
                     <PieChart>
@@ -678,8 +685,8 @@ function PopularJobsChart() {
                         data={chartData}
                         cx="50%"
                         cy="50%"
-                        innerRadius={isMobile ? 55 : 70}
-                        outerRadius={isMobile ? 75 : 100}
+                        innerRadius={isMobile ? 42 : 65}
+                        outerRadius={isMobile ? 58 : 90}
                         paddingAngle={3}
                         dataKey="count"
                         nameKey="name"

--- a/Frontend/src/pages/Flagged.tsx
+++ b/Frontend/src/pages/Flagged.tsx
@@ -15,7 +15,6 @@ import {
   Users,
   CreditCard,
   Star,
-  RefreshCw,
   ChevronRight,
 } from 'lucide-react';
 import { ReviewReportModal, TransactionDetailsModal } from '../components/Modals';
@@ -249,13 +248,7 @@ const Flagged: React.FC = () => {
               <p className="text-xs text-gray-500 font-medium">Review and resolve user complaints and reported content</p>
             </div>
             
-            <button 
-              onClick={() => refetch()}
-              className="flex items-center gap-1.5 text-gray-600 hover:text-gray-900 font-bold bg-gray-50 border border-gray-200 px-3 py-2 rounded-lg transition-colors text-xs"
-            >
-              <RefreshCw className="h-4 w-4" />
-              <span>REFRESH</span>
-            </button>
+
           </div>
 
           {/* Stats Cards Grid */}
@@ -320,12 +313,12 @@ const Flagged: React.FC = () => {
             />
           </div>
 
-          <div className="flex items-center gap-2 bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm">
-            <span className="text-xs font-bold text-gray-400">Limit:</span>
+          <div className="hidden md:flex items-center gap-2 md:order-3 shrink-0">
+            <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
             <select 
               value={itemsPerPage}
               onChange={(e) => setItemsPerPage(Number(e.target.value))}
-              className="bg-transparent text-xs font-bold text-gray-600 focus:outline-none"
+              className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
             >
               <option value={10}>10</option>
               <option value={20}>20</option>
@@ -353,7 +346,7 @@ const Flagged: React.FC = () => {
           ) : (
             <>
               {/* Desktop View */}
-              <div className="hidden lg:block bg-white flex-1 relative overflow-hidden">
+              <div className="hidden lg:block bg-white flex-1 relative">
                 <table className="min-w-full table-fixed border-separate border-spacing-0">
                   <thead className="bg-gray-50/80 backdrop-blur-md sticky top-0 z-20">
                     <tr className="border-b border-gray-200">

--- a/Frontend/src/pages/Jobs.tsx
+++ b/Frontend/src/pages/Jobs.tsx
@@ -10,8 +10,11 @@ import {
   Users,
   Briefcase,
   FolderOpen,
-  DollarSign,
+  Plus,
   RefreshCw,
+  LayoutGrid,
+  Table2,
+  DollarSign,
   ChevronRight,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
@@ -62,14 +65,16 @@ const Jobs: React.FC = () => {
   const [categories, setCategories] = useState<JobCategory[]>([]);
   const [professionsList, setProfessionsList] = useState<string[]>([]);
   const [iconTimestamp, setIconTimestamp] = useState(Date.now());
+  const [mobileViewType, setMobileViewType] = useState<'card' | 'table'>('card');
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
   // Resolver logic adapted from Dashboard.tsx for icons parity
   const resolveIconForJob = useMemo(() => (jobCategory: string, jobIcon?: string) => {
     if (!jobCategory) return { imagePath: '/assets/icons/categories/professional-services.png', label: 'General Service' };
-    
+
     // If a direct icon path or URL is provided, use it
     if (jobIcon && (jobIcon.startsWith('http') || jobIcon.includes('.'))) {
-      return { 
+      return {
         imagePath: jobIcon.startsWith('http') ? jobIcon : `/assets/icons/professions/${jobIcon}`,
         label: jobCategory
       };
@@ -229,11 +234,11 @@ const Jobs: React.FC = () => {
   };
 
   return (
-    <div className="fixed inset-0 md:left-72 flex flex-col bg-gray-50 mt-16 md:mt-0 h-screen overflow-hidden">
+    <div className="fixed top-16 md:top-0 bottom-0 left-0 md:left-72 right-0 flex flex-col bg-gray-50 overflow-hidden">
       {/* Header Section */}
       <div className="flex-shrink-0 bg-white border-b border-gray-200 z-30 shadow-sm relative">
         <div className="px-6 py-5">
-          <div className="flex items-center justify-between mb-6">
+          <div className="hidden md:flex items-center justify-between mb-6">
             <div>
               <div className="flex items-center gap-2 mb-1">
                 <span className="p-1.5 bg-blue-50 rounded-lg">
@@ -247,21 +252,15 @@ const Jobs: React.FC = () => {
                 Monitor and manage all service requests across the platform
               </p>
             </div>
-            
-            <button 
-              onClick={() => queryClient.invalidateQueries({ queryKey: ['jobs'] })}
-              className="flex items-center gap-1.5 text-gray-600 hover:text-gray-900 font-bold bg-gray-50 border border-gray-200 px-3 py-2 rounded-lg transition-colors text-xs"
-            >
-              <RefreshCw className="h-4 w-4" />
-              <span>REFRESH DATA</span>
-            </button>
+
+
           </div>
 
           {/* Stats Cards Grid */}
-          <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
-            <div className="cursor-pointer" onClick={() => setStatusFilter('all')}>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3 md:gap-4">
+            <div className="cursor-pointer transition-transform active:scale-95" onClick={() => setStatusFilter('all')}>
               <StatsCard
-                title="Total Jobs"
+                title="Total"
                 value={jobCounts.total.toLocaleString()}
                 icon={Briefcase}
                 color="blue"
@@ -270,9 +269,9 @@ const Jobs: React.FC = () => {
                 smallIcon={true}
               />
             </div>
-            <div className="cursor-pointer" onClick={() => setStatusFilter('open')}>
+            <div className="cursor-pointer transition-transform active:scale-95" onClick={() => setStatusFilter('open')}>
               <StatsCard
-                title="Open Jobs"
+                title="Open"
                 value={jobCounts.open.toLocaleString()}
                 icon={FolderOpen}
                 color="green"
@@ -281,7 +280,7 @@ const Jobs: React.FC = () => {
                 smallIcon={true}
               />
             </div>
-            <div className="cursor-pointer" onClick={() => setStatusFilter('in_progress')}>
+            <div className="cursor-pointer transition-transform active:scale-95" onClick={() => setStatusFilter('in_progress')}>
               <StatsCard
                 title="Assigned"
                 value={jobCounts.assigned.toLocaleString()}
@@ -292,9 +291,9 @@ const Jobs: React.FC = () => {
                 smallIcon={true}
               />
             </div>
-            <div className="cursor-pointer" onClick={() => setStatusFilter('completed')}>
+            <div className="cursor-pointer transition-transform active:scale-95" onClick={() => setStatusFilter('completed')}>
               <StatsCard
-                title="Completed"
+                title="Done"
                 value={jobCounts.completed.toLocaleString()}
                 icon={CheckCircle}
                 color="purple"
@@ -303,66 +302,104 @@ const Jobs: React.FC = () => {
                 smallIcon={true}
               />
             </div>
-            <div className="col-span-2 lg:col-span-1">
+            <div className="col-span-2 md:col-span-1 lg:col-span-1">
               <StatsCard
-                title="Total Revenue"
+                title="Revenue"
                 value={formatCurrency(jobCounts.totalValue)}
                 icon={DollarSign}
                 color="green"
                 variant="solid"
                 smallIcon={true}
+                horizontalMobile={true}
               />
             </div>
           </div>
         </div>
 
         {/* Filter Bar */}
-        <div className="px-6 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row items-center gap-4">
-          <div className="relative flex-1">
-            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
-            <input
-              type="text"
-              placeholder="Search by job title or description..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm"
-            />
-          </div>
+        <div className="px-4 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row md:items-center gap-3 md:gap-6">
+          {/* Row 1 on Mobile / Search on Desktop */}
+          <div className="flex items-center gap-2 md:contents">
+            <div className="relative flex-1 md:order-1">
+              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <input
+                type="text"
+                placeholder="Search jobs, categories, or IDs..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm h-10"
+              />
+            </div>
 
-          <div className="flex items-center gap-2">
-            <select
-              value={professionFilter}
-              onChange={(e) => setProfessionFilter(e.target.value)}
-              className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-bold text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
-            >
-              <option value="all">All Professions</option>
-              {professionsList.map(prof => (
-                <option key={prof} value={prof} className="capitalize">{prof}</option>
-              ))}
-            </select>
-
-            <select
-              value={paymentMethodFilter}
-              onChange={(e) => setPaymentMethodFilter(e.target.value)}
-              className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-bold text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
-            >
-              <option value="all">Payment Method</option>
-              <option value="wallet">Wallet</option>
-              <option value="cash">Cash</option>
-              <option value="xendit">Xendit</option>
-            </select>
-
-            <div className="flex items-center gap-2 bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm">
-              <span className="text-xs font-bold text-gray-400">Limit:</span>
+            {/* Mobile-only Limit */}
+            <div className="flex md:hidden items-center gap-1.5 px-2">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
                 onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
-                className="bg-transparent text-xs font-bold text-gray-600 focus:outline-none"
+                className="bg-transparent border-none text-xs font-black text-gray-600 focus:outline-none focus:ring-0 cursor-pointer pr-8"
               >
                 <option value={10}>10</option>
                 <option value={20}>20</option>
                 <option value={50}>50</option>
               </select>
+            </div>
+          </div>
+
+          {/* Row 2 on Mobile / Desktop Right-side group */}
+          <div className="flex items-center justify-between gap-3 md:flex-initial md:order-2 md:justify-end md:gap-6 shrink-0">
+            <div className="flex items-center gap-2 overflow-x-auto no-scrollbar pb-0.5 md:pb-0">
+              <select
+                value={professionFilter}
+                onChange={(e) => setProfessionFilter(e.target.value)}
+                className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-black uppercase tracking-wider text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 lg:min-w-[140px] max-w-[160px] truncate"
+              >
+                <option value="all">Professions</option>
+                {professionsList.map(prof => (
+                  <option key={prof} value={prof} className="capitalize">{prof}</option>
+                ))}
+              </select>
+
+              <select
+                value={paymentMethodFilter}
+                onChange={(e) => setPaymentMethodFilter(e.target.value)}
+                className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-black uppercase tracking-wider text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 min-w-[110px]"
+              >
+                <option value="all">Payment</option>
+                <option value="wallet">Wallet</option>
+                <option value="cash">Cash</option>
+                <option value="xendit">Xendit</option>
+              </select>
+            </div>
+
+            {/* Pagination Limit for Desktop */}
+            <div className="hidden md:flex items-center gap-2 md:order-3 shrink-0">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+              <select 
+                value={pagination.limit}
+                onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
+
+            {/* View Type Toggle - Mobile Only */}
+            <div className="flex md:hidden items-center bg-white border border-gray-200 rounded-[12px] p-1 shadow-sm shrink-0 md:order-4">
+               <button
+                 onClick={() => setMobileViewType('card')}
+                 className={`p-1.5 rounded-[10px] transition-all ${mobileViewType === 'card' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+               >
+                 <LayoutGrid className="h-3.5 w-3.5" />
+               </button>
+               <button
+                 onClick={() => setMobileViewType('table')}
+                 className={`p-1.5 rounded-[10px] transition-all ${mobileViewType === 'table' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+               >
+                 <Table2 className="h-3.5 w-3.5" />
+               </button>
             </div>
           </div>
         </div>
@@ -389,7 +426,7 @@ const Jobs: React.FC = () => {
           ) : (
             <>
               {/* Desktop View */}
-              <div className="hidden lg:block bg-white flex-1 relative overflow-hidden">
+              <div className="hidden md:block bg-white flex-1 relative">
                 <table className="min-w-full table-fixed border-separate border-spacing-0">
                   <thead className="bg-gray-50/80 backdrop-blur-md sticky top-0 z-20">
                     <tr className="border-b border-gray-200">
@@ -422,7 +459,7 @@ const Jobs: React.FC = () => {
                           <td className="px-6 py-2 border-b border-gray-300">
                             <div className="flex items-center gap-4">
                               <div className="h-14 w-14 flex-shrink-0 flex items-center justify-center">
-                                <img 
+                                <img
                                   src={`${iconData.imagePath}?t=${iconTimestamp}`}
                                   alt={job.category}
                                   className="h-14 w-14 object-contain group-hover:scale-105 transition-transform"
@@ -445,137 +482,207 @@ const Jobs: React.FC = () => {
                               </div>
                             </div>
                           </td>
-                        <td className="px-6 py-4 border-b border-gray-300">
-                          <div className="flex items-center gap-3">
-                            <div className="h-8 w-8 rounded-full bg-gray-100 flex items-center justify-center border border-gray-200 flex-shrink-0">
-                               <span className="text-[10px] font-bold text-gray-500">{getInitials(job.user?.name || 'U')}</span>
+                          <td className="px-6 py-4 border-b border-gray-300">
+                            <div className="flex items-center gap-3">
+                              <div className="h-8 w-8 rounded-full bg-gray-100 flex items-center justify-center border border-gray-200 flex-shrink-0">
+                                <span className="text-[10px] font-bold text-gray-500">{getInitials(job.user?.name || 'U')}</span>
+                              </div>
+                              <div className="min-w-0">
+                                <p className="text-xs font-bold text-gray-900 truncate">{job.user?.name || 'Anonymous'}</p>
+                                <p className="text-[10px] text-gray-400 truncate mt-0.5">{job.user?.email || 'No email provided'}</p>
+                              </div>
                             </div>
-                            <div className="min-w-0">
-                              <p className="text-xs font-bold text-gray-900 truncate">{job.user?.name || 'Anonymous'}</p>
-                              <p className="text-[10px] text-gray-400 truncate mt-0.5">{job.user?.email || 'No email provided'}</p>
+                          </td>
+                          <td className="px-6 py-4 border-b border-gray-300">
+                            <div className="flex justify-center">
+                              <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-wider border ${getJobStatusColor(job.status)} shadow-sm`}>
+                                {getJobStatusIcon(job.status)}
+                                {job.status.replace('_', ' ')}
+                              </span>
                             </div>
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 border-b border-gray-300">
-                          <div className="flex justify-center">
-                            <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-wider border ${getJobStatusColor(job.status)} shadow-sm`}>
-                              {getJobStatusIcon(job.status)}
-                              {job.status.replace('_', ' ')}
-                            </span>
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 text-center border-b border-gray-300">
-                          <div className="flex flex-col items-center">
-                            <p className="text-sm font-black text-gray-900">
-                              {formatCurrency(job.budget > 0 ? job.budget : (job.agreedPrice || job.acceptedProvider?.agreedPrice || 0))}
-                            </p>
-                            <div className="flex items-center gap-1 text-[9px] font-black text-gray-400 uppercase mt-0.5">
-                              <Wallet className="h-2.5 w-2.5" />
-                              {job.paymentMethod}
+                          </td>
+                          <td className="px-6 py-4 text-center border-b border-gray-300">
+                            <div className="flex flex-col items-center">
+                              <p className="text-sm font-black text-gray-900">
+                                {formatCurrency(job.budget > 0 ? job.budget : (job.agreedPrice || job.acceptedProvider?.agreedPrice || 0))}
+                              </p>
+                              <div className="flex items-center gap-1 text-[9px] font-black text-gray-400 uppercase mt-0.5">
+                                <Wallet className="h-2.5 w-2.5" />
+                                {job.paymentMethod}
+                              </div>
                             </div>
-                          </div>
-                        </td>
-                        <td className="px-6 py-4 border-b border-gray-300">
-                          <div className="flex flex-col">
-                            <p className="text-xs font-bold text-gray-900">
-                              {formatDistanceToNow(new Date(job.createdAt), { addSuffix: true })}
-                            </p>
-                            <div className="flex items-center gap-1 text-[10px] font-medium text-gray-400 mt-1">
-                              <Calendar className="h-3 w-3" />
-                              {new Date(job.createdAt).toLocaleDateString()}
+                          </td>
+                          <td className="px-6 py-4 border-b border-gray-300">
+                            <div className="flex flex-col">
+                              <p className="text-xs font-bold text-gray-900">
+                                {formatDistanceToNow(new Date(job.createdAt), { addSuffix: true })}
+                              </p>
+                              <div className="flex items-center gap-1 text-[10px] font-medium text-gray-400 mt-1">
+                                <Calendar className="h-3 w-3" />
+                                {new Date(job.createdAt).toLocaleDateString()}
+                              </div>
                             </div>
-                          </div>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
                 </table>
               </div>
 
-              <div className="lg:hidden flex-1 overflow-y-auto px-4 py-4 space-y-4">
-                {jobs.map((job) => {
-                  const iconData = resolveIconForJob(job.category, job.icon);
-                  return (
-                    <div
-                      key={job._id}
-                      onClick={() => openJobModal(job)}
-                      className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden active:scale-[0.98] transition-all"
-                    >
-                      <div className="flex items-center justify-between px-4 py-2.5 bg-gray-50/80 border-b border-gray-100">
-                        <div className="flex items-center gap-2">
-                          <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[9px] font-black uppercase tracking-[0.1em] border ${getJobStatusColor(job.status)}`}>
-                            {getJobStatusIcon(job.status)}
-                            {job.status.replace('_', ' ')}
-                          </span>
-                        </div>
-                        <span className="text-[10px] font-bold text-gray-400 bg-white px-2 py-0.5 rounded border border-gray-100 uppercase tracking-widest font-mono">
-                          {formatDistanceToNow(new Date(job.createdAt), { addSuffix: true })}
-                        </span>
-                      </div>
+              {/* Mobile Toggleable View */}
+              <div className="md:hidden flex-1 flex flex-col min-h-0 bg-white">
+                {mobileViewType === 'card' ? (
+                  <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
+                    {jobs.map((job) => {
+                      const iconData = resolveIconForJob(job.category, job.icon);
+                      return (
+                        <div
+                          key={job._id}
+                          onClick={() => openJobModal(job)}
+                          className="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden active:scale-[0.98] transition-all"
+                        >
+                          {/* Card Header: Status & Time */}
+                          <div className="flex items-center justify-between px-4 py-3 bg-gray-50/50 border-b border-gray-100">
+                            <div className="flex items-center gap-2">
+                              <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-wider border ${getJobStatusColor(job.status)} shadow-sm bg-white`}>
+                                {getJobStatusIcon(job.status)}
+                                {job.status.replace('_', ' ')}
+                              </span>
+                              {job.isUrgent && (
+                                <span className="px-2 py-1 rounded-full text-[9px] font-black uppercase tracking-widest bg-red-500 text-white shadow-sm ring-2 ring-red-100">
+                                  Urgent
+                                </span>
+                              )}
+                            </div>
+                            <div className="flex items-center gap-1.5 text-[10px] font-bold text-gray-400">
+                              <Clock className="h-3 w-3" />
+                              {formatDistanceToNow(new Date(job.createdAt), { addSuffix: true })}
+                            </div>
+                          </div>
 
-                      <div className="p-4">
-                         <div className="flex items-start gap-4 mb-4">
-                          <div className="relative flex-shrink-0">
-                                <div className="h-12 w-12 rounded-xl bg-gray-50 border border-gray-100 flex items-center justify-center overflow-hidden">
+                          {/* Card Content */}
+                          <div className="p-4">
+                            <div className="flex items-start gap-4 mb-4">
+                              <div className="relative flex-shrink-0">
+                                <div className="h-14 w-14 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center p-2 shadow-inner">
                                   <img 
                                     src={`${iconData.imagePath}?t=${iconTimestamp}`}
                                     alt={job.category}
-                                    className="h-8 w-8 object-contain"
+                                    className="h-10 w-10 object-contain"
                                     onError={(e) => {
                                       (e.target as HTMLImageElement).src = '/assets/icons/categories/professional-services.png';
                                       (e.target as HTMLImageElement).onerror = null;
                                     }}
                                   />
                                 </div>
-                            {job.isUrgent && (
-                              <div className="absolute -top-1 -right-1 w-5 h-5 bg-red-600 border-2 border-white rounded-full flex items-center justify-center shadow-lg animate-bounce">
-                                 <span className="text-[10px]">🔥</span>
                               </div>
-                            )}
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <h3 className="text-base font-black text-gray-900 leading-tight mb-1 truncate">
-                              {job.title}
-                            </h3>
-                            <div className="flex items-center gap-2">
-                               <span className="text-[9px] font-black text-gray-400 uppercase tracking-widest bg-gray-50 px-2 py-0.5 rounded border border-gray-100">
-                                 {iconData.label || job.category || 'General Service'}
-                               </span>
-                               <div className="flex items-center gap-1 text-[9px] font-black text-blue-600 uppercase tracking-widest">
-                                 <Users className="h-2.5 w-2.5" />
-                                 {job.applicationCount || 0} APPLICANTS
-                               </div>
+                              <div className="flex-1 min-w-0">
+                                <h3 className="text-base font-black text-gray-900 leading-tight mb-1 truncate">
+                                  {job.title}
+                                </h3>
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <span className="text-[10px] font-black text-blue-600 uppercase tracking-widest bg-blue-50 px-2 py-0.5 rounded border border-blue-100">
+                                    {iconData.label || job.category || 'General Service'}
+                                  </span>
+                                  <div className="flex items-center gap-1 text-[10px] font-black text-gray-400 uppercase tracking-widest">
+                                    <Users className="h-3 w-3" />
+                                    {job.applicationCount || 0}
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+
+                            {/* Customer Info Snippet */}
+                            <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-xl border border-gray-100">
+                              <div className="h-8 w-8 rounded-full bg-white border border-gray-200 flex items-center justify-center text-[10px] font-black text-gray-500 shadow-sm">
+                                {getInitials(job.user?.name || 'U')}
+                              </div>
+                              <div className="min-w-0">
+                                <p className="text-xs font-bold text-gray-900 truncate">{job.user?.name || 'Anonymous'}</p>
+                                <p className="text-[10px] text-gray-400 truncate tracking-tight">{job.user?.email || 'No email provided'}</p>
+                              </div>
+                            </div>
+
+                            {/* Price & Location */}
+                            <div className="grid grid-cols-2 gap-4 mt-4 pt-4 border-t border-dashed border-gray-200">
+                              <div className="flex flex-col">
+                                <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest">Offering Price</span>
+                                <div className="flex items-baseline gap-1 mt-0.5">
+                                  <span className="text-lg font-black text-gray-900 leading-none">
+                                    {formatCurrency(job.budget > 0 ? job.budget : (job.agreedPrice || job.acceptedProvider?.agreedPrice || 0))}
+                                  </span>
+                                  <span className="text-[9px] text-gray-400 font-bold uppercase">{job.paymentMethod}</span>
+                                </div>
+                              </div>
+                              <div className="flex flex-col items-end text-right">
+                                <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest">Location</span>
+                                <div className="flex items-center gap-1 text-[10px] font-bold text-gray-700 mt-1 max-w-full truncate">
+                                  <MapPin className="h-3 w-3 text-red-500" />
+                                  <span className="truncate">{job.locationDisplay || 'Remote'}</span>
+                                </div>
+                              </div>
                             </div>
                           </div>
-                         </div>
 
-                       <p className="text-xs text-gray-500 line-clamp-2 leading-relaxed mb-4 italic">
-                        "{job.description}"
-                       </p>
-
-                       <div className="grid grid-cols-2 gap-3 pt-4 border-t border-dashed border-gray-100">
-                          <div className="flex flex-col">
-                            <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest opacity-70">Price Offering</span>
-                            <span className="text-sm font-black text-gray-900">{formatCurrency(job.budget)}</span>
+                          {/* View Details Prompt */}
+                          <div className="px-4 py-2.5 bg-gray-50/30 border-t border-gray-100 flex items-center justify-center gap-1 text-[10px] font-black text-blue-600 uppercase tracking-widest">
+                            View Detailed Breakdown
+                            <ChevronRight className="h-3 w-3" />
                           </div>
-                          <div className="flex flex-col items-end">
-                            <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest opacity-70">Requested By</span>
-                            <span className="text-xs font-bold text-gray-900 truncate max-w-[120px]">{job.user?.name || 'Anonymous'}</span>
-                          </div>
-                       </div>
-                    </div>
-
-                    <div className="px-4 py-3 bg-gray-50/50 border-t border-gray-100 flex items-center justify-between">
-                       <div className="flex items-center gap-2 text-[9px] font-black text-gray-400 uppercase tracking-widest">
-                         <MapPin className="h-3 w-3" />
-                         {job.locationDisplay || 'Remote / Not specified'}
-                       </div>
-                       <ChevronRight className="h-4 w-4 text-gray-300" />
-                      </div>
-                    </div>
-                  );
-                })}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="flex-1 overflow-x-hidden">
+                    <table className="w-full table-fixed border-separate border-spacing-0">
+                      <thead className="bg-gray-50/80 sticky top-0 z-20">
+                        <tr>
+                          <th className="w-[60%] px-3 py-2.5 text-left text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Job</th>
+                          <th className="w-[20%] px-2 py-2.5 text-center text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Stat</th>
+                          <th className="w-[20%] px-3 py-2.5 text-right text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Price</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {jobs.map((job) => {
+                          const iconData = resolveIconForJob(job.category, job.icon);
+                          return (
+                            <tr 
+                              key={job._id} 
+                              onClick={() => openJobModal(job)}
+                              className="border-b border-gray-100 active:bg-gray-50 transition-colors"
+                            >
+                              <td className="px-3 py-3 overflow-hidden">
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <img 
+                                    src={`${iconData.imagePath}?t=${iconTimestamp}`} 
+                                    className="h-7 w-7 object-contain flex-shrink-0" 
+                                    alt="" 
+                                  />
+                                  <div className="min-w-0 flex-1">
+                                    <p className="text-[11px] font-black text-gray-900 truncate leading-tight">{job.title}</p>
+                                    <p className="text-[9px] text-gray-400 font-bold truncate uppercase">{job.user?.name}</p>
+                                  </div>
+                                </div>
+                              </td>
+                              <td className="px-2 py-3 text-center">
+                                <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[8px] font-black uppercase tracking-tight border ${getJobStatusColor(job.status)}`}>
+                                  {job.status.split('_')[0]}
+                                </span>
+                              </td>
+                              <td className="px-3 py-3 text-right">
+                                <p className="text-[11px] font-black text-gray-900">
+                                  {formatCurrency(job.budget || 0)}
+                                </p>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
               </div>
 
             </>
@@ -603,14 +710,14 @@ const Jobs: React.FC = () => {
                 <button
                   onClick={() => setPagination(prev => ({ ...prev, page: Math.max(1, prev.page - 1) }))}
                   disabled={pagination.page === 1}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"
                 >
                   Previous
                 </button>
                 <button
                   onClick={() => setPagination(prev => ({ ...prev, page: Math.min(pagination.pages, prev.page + 1) }))}
                   disabled={pagination.page === pagination.pages}
-                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"
                 >
                   Next
                 </button>

--- a/Frontend/src/pages/SettingsManagement.tsx
+++ b/Frontend/src/pages/SettingsManagement.tsx
@@ -1,9 +1,28 @@
 import React, { useState, useEffect } from 'react';
-import { UserPlus, ShieldAlert, Edit2, XCircle, Search, Briefcase, Shield, Users, CreditCard, MessageSquare } from 'lucide-react';
+import { 
+  UserPlus, 
+  ShieldAlert, 
+  Edit2, 
+  Search, 
+  Briefcase, 
+  Shield, 
+  Users, 
+  CreditCard, 
+  MessageSquare,
+  Lock,
+  ShieldCheck,
+  Activity,
+  UserCheck,
+  Filter as FilterIcon,
+  MoreVertical,
+  UserCog
+} from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { settingsService } from '../services';
 import CreateAdminModal from '../components/Settings/CreateAdminModal';
 import EditAdminModal from '../components/Settings/EditAdminModal';
+import StatsCard from '../components/Dashboard/StatsCard';
+import { getInitials } from '../utils';
 
 interface Permission {
   dashboard: boolean;
@@ -27,6 +46,7 @@ interface Admin {
   accountStatus?: string;
   isOnline?: boolean;
   lastLogin?: string;
+  profileImage?: string;
 }
 
 const SettingsManagement: React.FC = () => {
@@ -58,38 +78,37 @@ const SettingsManagement: React.FC = () => {
     }
   };
 
-
   const getAccessLevel = (role: string): { label: string; color: string } => {
     const normalizedRole = role.toLowerCase();
     if (normalizedRole === 'superadmin') {
-      return { label: 'Super Admin', color: 'bg-green-100 text-green-800' };
+      return { label: 'Super Admin', color: 'bg-green-50 text-green-700 border-green-100' };
     }
     if (normalizedRole === 'admin') {
-      return { label: 'Admin', color: 'bg-blue-100 text-blue-800' };
+      return { label: 'Admin', color: 'bg-blue-50 text-blue-700 border-blue-100' };
     }
     if (normalizedRole === 'finance') {
-      return { label: 'Finance', color: 'bg-yellow-100 text-yellow-800' };
+      return { label: 'Finance', color: 'bg-yellow-50 text-yellow-700 border-yellow-100' };
     }
     if (normalizedRole === 'customer support' || normalizedRole === 'support') {
-      return { label: 'Support', color: 'bg-purple-100 text-purple-800' };
+      return { label: 'Support', color: 'bg-purple-50 text-purple-700 border-purple-100' };
     }
-    return { label: 'Limited Access', color: 'bg-gray-100 text-gray-800' };
+    return { label: 'Limited Access', color: 'bg-gray-50 text-gray-700 border-gray-100' };
   };
 
-  const getAccountStatus = (status?: string): { label: string; color: string } => {
+  const getAccountStatus = (status?: string): { label: string; color: string; icon: React.ReactNode } => {
     if (status === 'active') {
-      return { label: 'Active', color: 'bg-green-100 text-green-800' };
+      return { label: 'Active', color: 'bg-green-50 text-green-700 border-green-100', icon: <UserCheck className="w-3 h-3" /> };
     }
     if (status === 'suspended') {
-      return { label: 'Suspended', color: 'bg-yellow-100 text-yellow-800' };
+      return { label: 'Suspended', color: 'bg-yellow-50 text-yellow-700 border-yellow-100', icon: <Activity className="w-3 h-3" /> };
     }
     if (status === 'banned') {
-      return { label: 'Banned', color: 'bg-red-100 text-red-800' };
+      return { label: 'Banned', color: 'bg-red-50 text-red-700 border-red-100', icon: <Lock className="w-3 h-3" /> };
     }
     if (status === 'restricted') {
-      return { label: 'Restricted', color: 'bg-orange-100 text-orange-800' };
+      return { label: 'Restricted', color: 'bg-orange-50 text-orange-700 border-orange-100', icon: <ShieldAlert className="w-3 h-3" /> };
     }
-    return { label: 'Unknown', color: 'bg-gray-100 text-gray-800' };
+    return { label: 'Unknown', color: 'bg-gray-50 text-gray-700 border-gray-100', icon: <Shield className="w-3 h-3" /> };
   };
 
   const formatLastLogin = (lastLogin?: string): string => {
@@ -115,37 +134,10 @@ const SettingsManagement: React.FC = () => {
 
   const getPermissionTemplate = (permissions: Permission): { name: string; color: string } => {
     if (Object.values(permissions).every(val => val === true)) {
-      return { name: 'Full Access', color: 'bg-green-100 text-green-800' };
+      return { name: 'Full Access', color: 'bg-green-50 text-green-700 border-green-100' };
     }
 
-    if (
-      permissions.dashboard === true &&
-      permissions.users === true &&
-      permissions.jobs === true &&
-      permissions.transactions === false &&
-      permissions.verifications === true &&
-      permissions.support === false &&
-      permissions.activity === true &&
-      permissions.flagged === true &&
-      permissions.settings === false
-    ) {
-      return { name: 'Admin', color: 'bg-blue-100 text-blue-800' };
-    }
-
-    if (
-      permissions.dashboard === true &&
-      permissions.users === false &&
-      permissions.jobs === false &&
-      permissions.transactions === true &&
-      permissions.verifications === false &&
-      permissions.support === true &&
-      permissions.activity === true &&
-      permissions.flagged === false &&
-      permissions.settings === false
-    ) {
-      return { name: 'Finance', color: 'bg-yellow-100 text-yellow-800' };
-    }
-
+    // Support Template
     if (
       permissions.dashboard === true &&
       permissions.users === true &&
@@ -157,10 +149,40 @@ const SettingsManagement: React.FC = () => {
       permissions.flagged === true &&
       permissions.settings === false
     ) {
-      return { name: 'Support', color: 'bg-purple-100 text-purple-800' };
+      return { name: 'Support', color: 'bg-purple-50 text-purple-700 border-purple-100' };
     }
 
-    return { name: 'Custom', color: 'bg-gray-100 text-gray-800' };
+    // Admin Template
+    if (
+      permissions.dashboard === true &&
+      permissions.users === true &&
+      permissions.jobs === true &&
+      permissions.transactions === true &&
+      permissions.verifications === true &&
+      permissions.support === true &&
+      permissions.activity === true &&
+      permissions.flagged === true &&
+      permissions.settings === false
+    ) {
+      return { name: 'Admin', color: 'bg-blue-50 text-blue-700 border-blue-100' };
+    }
+
+    // Finance Template
+    if (
+      permissions.dashboard === true &&
+      permissions.users === false &&
+      permissions.jobs === false &&
+      permissions.transactions === true &&
+      permissions.verifications === false &&
+      permissions.support === true &&
+      permissions.activity === true &&
+      permissions.flagged === false &&
+      permissions.settings === false
+    ) {
+      return { name: 'Finance', color: 'bg-yellow-50 text-yellow-700 border-yellow-100' };
+    }
+
+    return { name: 'Customized', color: 'bg-slate-50 text-slate-700 border-slate-100' };
   };
 
   const handleEdit = (admin: Admin) => {
@@ -182,7 +204,7 @@ const SettingsManagement: React.FC = () => {
         if (filter === 'superadmin') return role === 'superadmin';
         if (filter === 'admin') return role === 'admin';
         if (filter === 'finance') return role === 'finance';
-        if (filter === 'support') return role === 'customer support';
+        if (filter === 'support') return role === 'customer support' || role === 'support';
         return true;
       });
     }
@@ -204,16 +226,30 @@ const SettingsManagement: React.FC = () => {
   const superAdminCount = admins.filter(a => a.role.toLowerCase() === 'superadmin').length;
   const adminCount = admins.filter(a => a.role.toLowerCase() === 'admin').length;
   const financeCount = admins.filter(a => a.role.toLowerCase() === 'finance').length;
-  const supportCount = admins.filter(a => a.role.toLowerCase() === 'customer support').length;
+  const supportCount = admins.filter(a => a.role.toLowerCase() === 'customer support' || a.role.toLowerCase() === 'support').length;
 
   if (user?.role !== 'superadmin') {
     return (
-      <div className="fixed inset-0 md:left-72 flex items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <ShieldAlert className="h-16 w-16 text-red-500 mx-auto mb-4" />
-          <h2 className="text-2xl font-bold text-gray-900 mb-2">Access Denied</h2>
-          <p className="text-gray-600">You do not have permission to access this page.</p>
-          <p className="text-sm text-gray-500 mt-2">Only super administrators can access settings.</p>
+      <div className="fixed inset-0 md:left-72 flex items-center justify-center bg-gray-50 mt-16 md:mt-0">
+        <div className="flex flex-col items-center gap-6 max-w-sm px-6 text-center">
+          <div className="relative">
+            <div className="h-24 w-24 rounded-full bg-red-50 flex items-center justify-center border-4 border-white shadow-xl">
+              <ShieldAlert className="h-12 w-12 text-red-500" />
+            </div>
+            <div className="absolute -bottom-2 -right-2 bg-white p-2 rounded-full shadow-lg border border-red-100">
+              <Lock className="w-5 h-5 text-red-600" />
+            </div>
+          </div>
+          <div>
+            <h2 className="text-2xl font-black text-gray-900 mb-2 tracking-tight uppercase italic">Access Denied</h2>
+            <p className="text-sm text-gray-500 font-medium">
+              You do not have the required permissions to access administrative settings.
+            </p>
+            <div className="mt-6 flex items-center justify-center gap-2 py-2 px-4 bg-red-50 rounded-full border border-red-100 shadow-sm shadow-red-500/10">
+              <ShieldCheck className="w-4 h-4 text-red-600" />
+              <span className="text-[10px] font-black text-red-700 uppercase tracking-widest">Super Admin Eyes Only</span>
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -221,15 +257,23 @@ const SettingsManagement: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="fixed inset-0 md:left-72 flex items-center justify-center bg-gray-50">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
-        <span className="ml-3 text-gray-600">Loading admins...</span>
+      <div className="fixed inset-0 md:left-72 flex items-center justify-center bg-gray-50/50 backdrop-blur-sm z-50">
+        <div className="flex flex-col items-center gap-4">
+          <div className="relative">
+            <div className="h-16 w-16 rounded-full border-4 border-gray-100 border-t-blue-600 animate-spin" />
+            <UserCog className="absolute inset-0 m-auto h-6 w-6 text-blue-600 animate-pulse" />
+          </div>
+          <div className="flex flex-col items-center italic">
+            <p className="text-sm font-black text-gray-900 tracking-widest uppercase">Loading Admin Directory</p>
+            <p className="text-[10px] text-gray-400 font-bold uppercase tracking-[0.2em] mt-1">Verifying System Access</p>
+          </div>
+        </div>
       </div>
     );
   }
 
   return (
-    <>
+    <div className="fixed inset-0 md:left-72 flex flex-col bg-gray-50 mt-16 md:mt-0 h-screen overflow-hidden text-gray-700">
       <CreateAdminModal
         isOpen={isCreateModalOpen}
         onClose={() => setIsCreateModalOpen(false)}
@@ -243,328 +287,305 @@ const SettingsManagement: React.FC = () => {
         admin={selectedAdmin}
       />
 
-      <div className="fixed inset-0 md:left-72 flex flex-col bg-gray-50">
-        <div className="flex-shrink-0 bg-white border-b border-gray-200 px-4 md:px-6 py-4">
-          <div className="flex flex-col gap-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center min-w-0">
-                <div className="min-w-0">
-                  <h1 className="text-xl md:text-2xl font-bold text-gray-900">Admin Management</h1>
-                  <p className="text-xs md:text-sm text-gray-500 mt-1">
-                    Manage admin accounts and configure system permissions
-                  </p>
-                </div>
+      <div className="flex-shrink-0 bg-white border-b border-gray-200 z-30 shadow-sm relative">
+        <div className="px-6 py-5">
+          <div className="flex items-center justify-between mb-6">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <span className="p-1.5 bg-blue-50 rounded-lg">
+                  <ShieldCheck className="h-5 w-5 text-blue-600" />
+                </span>
+                <h1 className="text-2xl font-black text-gray-900 tracking-tight truncate">
+                  Admin Authority
+                </h1>
               </div>
-
-              <button
-                onClick={() => setIsCreateModalOpen(true)}
-                className="inline-flex items-center px-3 md:px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition-colors shadow-sm flex-shrink-0"
-              >
-                <UserPlus className="h-4 w-4 md:mr-2" />
-                <span className="hidden md:inline">Create new admin</span>
-              </button>
+              <p className="text-xs text-gray-500 font-medium">
+                Manage system administrators, configure granular permissions and monitor account activity
+              </p>
             </div>
+            
+            <button
+              onClick={() => setIsCreateModalOpen(true)}
+              className="group flex items-center gap-2 px-4 py-2.5 bg-gray-900 text-white rounded-xl hover:bg-black transition-all shadow-lg shadow-gray-900/10 active:scale-95 flex-shrink-0"
+            >
+              <UserPlus className="h-4 w-4 group-hover:rotate-12 transition-transform" />
+              <span className="text-xs font-black uppercase tracking-widest">New Admin</span>
+            </button>
+          </div>
 
-            {/* Mobile View Counters */}
-            <div className="grid grid-cols-2 gap-2 md:hidden">
-              <div
-                onClick={() => setFilter('all')}
-                className={`rounded-lg p-2.5 border cursor-pointer transition-all flex items-center justify-between bg-gray-50 border-gray-200 ${filter === 'all' ? 'border-gray-500 ring-2 ring-gray-400' : ''
-                  }`}
-              >
-                <div className="flex items-center gap-2">
-                  <Briefcase className="h-4 w-4 text-gray-600" />
-                  <span className="text-xs font-semibold text-gray-700 px-0.5">Total</span>
-                </div>
-                <span className="text-sm font-bold text-gray-900">{admins.length}</span>
-              </div>
-
-              <div
-                onClick={() => setFilter('superadmin')}
-                className={`rounded-lg p-2.5 border cursor-pointer transition-all flex items-center justify-between bg-green-50 border-green-200 ${filter === 'superadmin' ? 'border-green-500 ring-2 ring-green-300' : ''
-                  }`}
-              >
-                <div className="flex items-center gap-2">
-                  <Shield className="h-4 w-4 text-green-600" />
-                  <span className="text-xs font-semibold text-gray-700 px-0.5">Super</span>
-                </div>
-                <span className="text-sm font-bold text-green-700">{superAdminCount}</span>
-              </div>
-
-              <div
-                onClick={() => setFilter('admin')}
-                className={`rounded-lg p-2.5 border cursor-pointer transition-all flex items-center justify-between bg-blue-50 border-blue-200 ${filter === 'admin' ? 'border-blue-500 ring-2 ring-blue-300' : ''
-                  }`}
-              >
-                <div className="flex items-center gap-2">
-                  <Users className="h-4 w-4 text-blue-600" />
-                  <span className="text-xs font-semibold text-gray-700 px-0.5">Admin</span>
-                </div>
-                <span className="text-sm font-bold text-blue-700">{adminCount}</span>
-              </div>
-
-              <div
-                onClick={() => setFilter('finance')}
-                className={`rounded-lg p-2.5 border cursor-pointer transition-all flex items-center justify-between bg-yellow-50 border-yellow-200 ${filter === 'finance' ? 'border-yellow-500 ring-2 ring-yellow-300' : ''
-                  }`}
-              >
-                <div className="flex items-center gap-2">
-                  <CreditCard className="h-4 w-4 text-yellow-600" />
-                  <span className="text-xs font-semibold text-gray-700 px-0.5">Finance</span>
-                </div>
-                <span className="text-sm font-bold text-yellow-700">{financeCount}</span>
-              </div>
-
-              <div
-                onClick={() => setFilter('support')}
-                className={`col-span-2 rounded-lg p-2.5 border cursor-pointer transition-all flex items-center justify-between bg-purple-50 border-purple-200 ${filter === 'support' ? 'border-purple-500 ring-2 ring-purple-300' : ''
-                  }`}
-              >
-                <div className="flex items-center gap-2">
-                  <MessageSquare className="h-4 w-4 text-purple-600" />
-                  <span className="text-xs font-semibold text-gray-700 px-0.5">Support</span>
-                </div>
-                <span className="text-sm font-bold text-purple-700">{supportCount}</span>
-              </div>
+          <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
+            <div className="cursor-pointer" onClick={() => setFilter('all')}>
+              <StatsCard
+                title="All Management"
+                value={admins.length.toString()}
+                icon={Briefcase}
+                color="blue"
+                variant="tinted"
+                isActive={filter === 'all'}
+                smallIcon={true}
+              />
             </div>
-
-            {/* Desktop View Counters */}
-            <div className="hidden md:grid grid-cols-5 gap-3">
-              <div
-                onClick={() => setFilter('all')}
-                className={`bg-gradient-to-br from-gray-50 to-gray-100 rounded-lg p-3 border cursor-pointer hover:shadow-lg transition-all ${filter === 'all' ? 'border-gray-500 ring-2 ring-gray-500 shadow-lg' : 'border-gray-200'
-                  }`}
-              >
-                <p className="text-xs text-gray-600 font-medium mb-1">All Management</p>
-                <p className="text-xl md:text-2xl font-bold text-gray-900">{admins.length}</p>
-              </div>
-
-              <div
-                onClick={() => setFilter('superadmin')}
-                className={`bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-3 border cursor-pointer hover:shadow-lg transition-all ${filter === 'superadmin' ? 'border-green-500 ring-2 ring-green-400 shadow-lg' : 'border-green-200'
-                  }`}
-              >
-                <p className="text-xs text-gray-600 font-medium mb-1">Super Admin</p>
-                <p className="text-xl md:text-2xl font-bold text-gray-900">{superAdminCount}</p>
-              </div>
-
-              <div
-                onClick={() => setFilter('admin')}
-                className={`bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg p-3 border cursor-pointer hover:shadow-lg transition-all ${filter === 'admin' ? 'border-blue-500 ring-2 ring-blue-400 shadow-lg' : 'border-blue-200'
-                  }`}
-              >
-                <p className="text-xs text-gray-600 font-medium mb-1">Admin</p>
-                <p className="text-xl md:text-2xl font-bold text-gray-900">{adminCount}</p>
-              </div>
-
-              <div
-                onClick={() => setFilter('finance')}
-                className={`bg-gradient-to-br from-yellow-50 to-yellow-100 rounded-lg p-3 border cursor-pointer hover:shadow-lg transition-all ${filter === 'finance' ? 'border-yellow-500 ring-2 ring-yellow-400 shadow-lg' : 'border-yellow-200'
-                  }`}
-              >
-                <p className="text-xs text-gray-600 font-medium mb-1">Finance</p>
-                <p className="text-xl md:text-2xl font-bold text-gray-900">{financeCount}</p>
-              </div>
-
-              <div
-                onClick={() => setFilter('support')}
-                className={`bg-gradient-to-br from-purple-50 to-purple-100 rounded-lg p-3 border cursor-pointer hover:shadow-lg transition-all ${filter === 'support' ? 'border-purple-500 ring-2 ring-purple-400 shadow-lg' : 'border-purple-200'
-                  }`}
-              >
-                <p className="text-xs text-gray-600 font-medium mb-1">Support</p>
-                <p className="text-xl md:text-2xl font-bold text-gray-900">{supportCount}</p>
-              </div>
+            <div className="cursor-pointer" onClick={() => setFilter('superadmin')}>
+              <StatsCard
+                title="Super Admin"
+                value={superAdminCount.toString()}
+                icon={Shield}
+                color="green"
+                variant="tinted"
+                isActive={filter === 'superadmin'}
+                smallIcon={true}
+              />
             </div>
-
-            <div className="flex flex-col sm:flex-row gap-3">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
-                <input
-                  type="text"
-                  placeholder="Search by name, email, UID, or role..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="pl-10 pr-4 py-2 w-full border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
-                />
-              </div>
+            <div className="cursor-pointer" onClick={() => setFilter('admin')}>
+              <StatsCard
+                title="Admin"
+                value={adminCount.toString()}
+                icon={Users}
+                color="indigo"
+                variant="tinted"
+                isActive={filter === 'admin'}
+                smallIcon={true}
+              />
+            </div>
+            <div className="cursor-pointer" onClick={() => setFilter('finance')}>
+              <StatsCard
+                title="Finance"
+                value={financeCount.toString()}
+                icon={CreditCard}
+                color="orange"
+                variant="tinted"
+                isActive={filter === 'finance'}
+                smallIcon={true}
+              />
+            </div>
+            <div className="hidden lg:block cursor-pointer" onClick={() => setFilter('support')}>
+              <StatsCard
+                title="Support"
+                value={supportCount.toString()}
+                icon={MessageSquare}
+                color="purple"
+                variant="tinted"
+                isActive={filter === 'support'}
+                smallIcon={true}
+              />
             </div>
           </div>
         </div>
 
-        {error && (
-          <div className="flex-shrink-0 mx-4 md:mx-6 mt-4 bg-red-50 border-l-4 border-red-400 text-red-700 px-3 md:px-4 py-3 rounded">
-            <div className="flex items-center">
-              <XCircle className="h-4 w-4 md:h-5 md:w-5 mr-2 flex-shrink-0" />
-              <span className="text-sm">Error: {error}</span>
-            </div>
+        <div className="px-6 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row items-center gap-4">
+          <div className="relative flex-1">
+            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+            <input
+              type="text"
+              placeholder="Search by name, email, UID, or role..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm shadow-indigo-100/10"
+            />
           </div>
-        )}
 
-        <div className="flex-1 overflow-hidden flex flex-col">
-          <div className="flex-1 overflow-y-auto">
-            {filteredAdmins.length === 0 ? (
-              <div className="h-full flex items-center justify-center bg-white p-12">
-                <div className="text-center">
-                  <ShieldAlert className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                  <h2 className="text-xl font-semibold text-gray-900 mb-2">
-                    {searchTerm ? 'No matching admins found' :
-                      filter === 'all' ? 'No admin accounts found' : `No ${filter} admins`}
-                  </h2>
-                  <p className="text-gray-600">
-                    {searchTerm ? 'Try adjusting your search terms' :
-                      admins.length === 0 ? 'Create a new admin account to get started.' : 'No admins found for this filter.'}
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <>
-                <div className="hidden md:block bg-white overflow-x-auto">
-                  <table className="min-w-full w-full table-auto">
-                    <thead className="bg-gray-50 border-b border-gray-200">
-                      <tr>
-                        <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                          UID
-                        </th>
-                        <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                          Full Name
-                        </th>
-                        <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                          Email
-                        </th>
-                        <th className="px-4 lg:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                          Status
-                        </th>
-                        <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                          Role
-                        </th>
-                        <th className="px-4 lg:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                          Permissions
-                        </th>
-                        <th className="px-4 lg:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                          Last Login
-                        </th>
-                        <th className="px-4 lg:px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                          Actions
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="bg-white">
-                      {filteredAdmins.map((admin, index) => (
-                        <React.Fragment key={admin._id}>
-                          <tr
-                            onClick={() => handleEdit(admin)}
-                            className="hover:bg-gray-50 transition-colors cursor-pointer"
-                          >
-                            <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                              {admin.uid}
-                            </td>
-                            <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                              {admin.fullName}
-                            </td>
-                            <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                              {admin.email}
-                            </td>
-                            <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
-                              <div className="flex items-center justify-center">
-                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getAccountStatus(admin.accountStatus).color
-                                  }`}>
-                                  {getAccountStatus(admin.accountStatus).label}
-                                </span>
-                              </div>
-                            </td>
-                            <td className="px-4 lg:px-6 py-4 whitespace-nowrap">
-                              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
-                                {admin.role}
-                              </span>
-                            </td>
-                            <td className="px-4 lg:px-6 py-4">
-                              <div className="flex items-center justify-center">
-                                <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium ${getPermissionTemplate(admin.permissions).color
-                                  }`}>
-                                  {getPermissionTemplate(admin.permissions).name}
-                                </span>
-                              </div>
-                            </td>
-                            <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                              {formatLastLogin(admin.lastLogin)}
-                            </td>
-                            <td className="px-4 lg:px-6 py-4 whitespace-nowrap text-center">
-                              <span className="inline-flex items-center text-blue-600 text-sm font-medium">
-                                <Edit2 className="h-3 w-3 mr-1" />
-                                Edit
-                              </span>
-                            </td>
-                          </tr>
-                          {index < filteredAdmins.length - 1 && (
-                            <tr>
-                              <td colSpan={8} className="p-0">
-                                <div className="border-b border-gray-200" />
-                              </td>
-                            </tr>
-                          )}
-                        </React.Fragment>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
+          <div className="flex items-center gap-1.5 p-1 bg-white border border-gray-100 rounded-xl shadow-sm">
+             <button 
+                onClick={() => setFilter('all')}
+                className={`px-3 py-1.5 text-[10px] font-black uppercase tracking-wider rounded-lg transition-all ${filter === 'all' ? 'bg-gray-900 text-white' : 'text-gray-400 hover:text-gray-600'}`}
+             >
+               All
+             </button>
+             <button 
+                onClick={() => setFilter('superadmin')}
+                className={`px-3 py-1.5 text-[10px] font-black uppercase tracking-wider rounded-lg transition-all ${filter === 'superadmin' ? 'bg-green-600 text-white' : 'text-gray-400 hover:text-gray-600'}`}
+             >
+               Super
+             </button>
+             <button 
+                onClick={() => setFilter('finance')}
+                className={`px-3 py-1.5 text-[10px] font-black uppercase tracking-wider rounded-lg transition-all ${filter === 'finance' ? 'bg-yellow-600 text-white' : 'text-gray-400 hover:text-gray-600'}`}
+             >
+               Finance
+             </button>
+             <button 
+                onClick={() => setFilter('support')}
+                className={`px-3 py-1.5 text-[10px] font-black uppercase tracking-wider rounded-lg transition-all ${filter === 'support' ? 'bg-purple-600 text-white' : 'text-gray-400 hover:text-gray-600'}`}
+             >
+               Support
+             </button>
+          </div>
 
-                <div className="md:hidden px-4 py-4 space-y-3">
-                  {filteredAdmins.map((admin) => {
-                    return (
-                      <div
-                        key={admin._id}
-                        onClick={() => handleEdit(admin)}
-                        className="bg-white rounded-lg border border-gray-200 overflow-hidden cursor-pointer hover:shadow-md transition-all"
-                      >
-                        <div className="p-4">
-                          <div className="flex items-start justify-between mb-2">
-                            <div className="flex-1 min-w-0">
-                              <h3 className="text-base font-semibold text-gray-900">{admin.fullName}</h3>
-                              <p className="text-sm text-gray-600 truncate">{admin.email}</p>
-                            </div>
-                            <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-blue-100 text-blue-800 flex-shrink-0 ml-2">
-                              {admin.role}
-                            </span>
-                          </div>
-
-                          <div className="flex items-center justify-between mb-3">
-                            <p className="text-xs text-gray-500">{admin.uid}</p>
-                            <div className="flex items-center gap-2">
-                              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getPermissionTemplate(admin.permissions).color
-                                }`}>
-                                {getPermissionTemplate(admin.permissions).name}
-                              </span>
-                              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${getAccountStatus(admin.accountStatus).color
-                                }`}>
-                                {getAccountStatus(admin.accountStatus).label}
-                              </span>
-                            </div>
-                          </div>
-
-                          <p className="text-xs text-gray-500 mb-3">
-                            Last login: <span className="font-medium text-gray-700">{formatLastLogin(admin.lastLogin)}</span>
-                          </p>
-
-                          <div className="flex items-center justify-between">
-                            <div className="flex items-center gap-2">
-                              <span className="text-sm text-gray-600 font-medium">Access Level:</span>
-                              <span className={`inline-flex items-center px-3 py-1 rounded-full text-xs font-medium ${getAccessLevel(admin.role).color
-                                }`}>
-                                {getAccessLevel(admin.role).label}
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </>
-            )}
+          <div className="flex items-center gap-2 bg-white px-3 py-2 border border-gray-100 rounded-xl shadow-sm">
+            <FilterIcon className="h-4 w-4 text-gray-400" />
+            <div className="text-[10px] font-black text-gray-400 uppercase tracking-widest">Displaying {filteredAdmins.length} Results</div>
           </div>
         </div>
       </div>
-    </>
+
+      {error && (
+        <div className="mx-6 mt-4 p-3 bg-red-50 border border-red-100 rounded-xl flex items-center gap-3 text-red-600 animate-in fade-in slide-in-from-top-2 duration-300">
+          <ShieldAlert className="h-4 w-4" />
+          <span className="text-xs font-bold uppercase tracking-tight">Access Error: {error}</span>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-hidden flex flex-col">
+        <div className="flex-1 overflow-y-auto">
+          {filteredAdmins.length === 0 ? (
+            <div className="bg-white p-12 text-center">
+              <div className="text-gray-400 mb-4">
+                <ShieldAlert className="h-12 w-12 mx-auto" />
+              </div>
+              <p className="text-gray-600 font-medium italic uppercase tracking-widest text-sm">No administrators found</p>
+              <p className="text-xs text-gray-400 mt-1 uppercase font-bold tracking-tighter">Adjust your filters or verify directory sync</p>
+            </div>
+          ) : (
+            <>
+              <div className="hidden md:block bg-white">
+                <table className="min-w-full">
+                  <thead className="bg-gray-50/80 backdrop-blur-md sticky top-0 z-10 border-b-2 border-gray-200">
+                    <tr>
+                      <th className="px-6 py-4 text-left text-xs font-black text-gray-600 uppercase tracking-widest">Identity</th>
+                      <th className="px-6 py-4 text-center text-xs font-black text-gray-600 uppercase tracking-widest">Authority</th>
+                      <th className="px-6 py-4 text-center text-xs font-black text-gray-600 uppercase tracking-widest">Status</th>
+                      <th className="px-6 py-4 text-center text-xs font-black text-gray-600 uppercase tracking-widest">Permissions</th>
+                      <th className="px-6 py-4 text-left text-xs font-black text-gray-600 uppercase tracking-widest">Last Activity</th>
+                      <th className="px-6 py-4 text-center text-xs font-black text-gray-600 uppercase tracking-widest w-10"></th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white">
+                    {filteredAdmins.map((admin) => (
+                      <tr
+                        key={admin._id}
+                        onClick={() => handleEdit(admin)}
+                        className="hover:bg-gray-50/80 transition-all cursor-pointer group border-b border-gray-100"
+                      >
+                        <td className="px-6 py-2.5 whitespace-nowrap">
+                          <div className="flex items-center gap-3">
+                            <div className="relative">
+                              {admin.profileImage ? (
+                                <img
+                                  src={admin.profileImage}
+                                  alt={admin.fullName}
+                                  className="w-10 h-10 rounded-full object-cover border border-gray-100 shadow-sm"
+                                />
+                              ) : (
+                                <div className="w-10 h-10 rounded-full bg-indigo-50 flex items-center justify-center border border-indigo-100 shadow-sm transition-transform group-hover:scale-110">
+                                  <span className="text-sm font-black text-indigo-600">
+                                    {getInitials(admin.fullName)}
+                                  </span>
+                                </div>
+                              )}
+                              <div className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-white shadow-sm ${admin.isOnline ? 'bg-green-500' : 'bg-gray-300'}`} />
+                            </div>
+                            <div className="min-w-0">
+                              <div className="text-sm font-black text-gray-900 truncate leading-tight">{admin.fullName}</div>
+                              <div className="text-[10px] text-gray-400 font-bold uppercase tracking-wider flex items-center gap-1">
+                                <span>{admin.email}</span>
+                                <span className="text-gray-300">•</span>
+                                <span className="font-mono text-gray-400">ID: {admin.uid}</span>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-center">
+                          <span className={`inline-flex items-center px-3 py-1 rounded-full text-[9px] font-black uppercase tracking-widest border shadow-sm ${getAccessLevel(admin.role).color}`}>
+                            {getAccessLevel(admin.role).label}
+                          </span>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-center">
+                          <span className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-[9px] font-black uppercase tracking-widest border transition-all shadow-sm ${getAccountStatus(admin.accountStatus).color}`}>
+                            {getAccountStatus(admin.accountStatus).icon}
+                            {getAccountStatus(admin.accountStatus).label}
+                          </span>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-center">
+                          <div className="flex items-center justify-center">
+                            <span className={`inline-flex items-center px-1.5 py-0.5 rounded-full text-[9px] font-black uppercase tracking-widest border shadow-sm ${getPermissionTemplate(admin.permissions).color}`}>
+                              {getPermissionTemplate(admin.permissions).name}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="text-xs font-black text-gray-700">{formatLastLogin(admin.lastLogin)}</div>
+                          <div className="text-[9px] font-bold text-gray-400 uppercase tracking-widest mt-0.5 italic">Session Activity</div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-center">
+                          <div className="flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+                             <div className="p-1.5 text-blue-600 bg-blue-50 rounded-lg hover:bg-blue-100 transition-colors">
+                                <Edit2 className="h-4 w-4" />
+                             </div>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="md:hidden px-4 py-4 space-y-4">
+                {filteredAdmins.map((admin) => (
+                  <div
+                    key={admin._id}
+                    onClick={() => handleEdit(admin)}
+                    className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden active:scale-[0.98] transition-all"
+                  >
+                    <div className="flex items-center justify-between px-4 py-3 bg-gray-50/80 border-b border-gray-100">
+                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[9px] font-black uppercase tracking-widest border shadow-sm ${getAccessLevel(admin.role).color}`}>
+                        {getAccessLevel(admin.role).label}
+                      </span>
+                      <div className="p-1.5 bg-white border border-gray-100 rounded-lg shadow-sm">
+                        <MoreVertical className="h-3 w-3 text-gray-400" />
+                      </div>
+                    </div>
+                    
+                    <div className="p-4">
+                      <div className="flex items-start gap-3 mb-4">
+                         <div className="relative">
+                          {admin.profileImage ? (
+                            <img
+                              src={admin.profileImage}
+                              alt={admin.fullName}
+                              className="h-12 w-12 rounded-2xl object-cover border border-gray-100 shadow-sm"
+                            />
+                          ) : (
+                            <div className="h-12 w-12 rounded-2xl bg-indigo-50 flex items-center justify-center border border-indigo-100 shadow-sm">
+                              <span className="text-lg font-black text-indigo-600">
+                                {getInitials(admin.fullName)}
+                              </span>
+                            </div>
+                          )}
+                          <div className={`absolute -bottom-1 -right-1 w-3.5 h-3.5 rounded-full border-3 border-white shadow-sm ${admin.isOnline ? 'bg-green-500' : 'bg-gray-300'}`} />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <h3 className="text-sm font-black text-gray-900 leading-tight mb-0.5">{admin.fullName}</h3>
+                          <p className="text-[10px] text-gray-400 font-bold uppercase tracking-wider truncate mb-2">{admin.email}</p>
+                          <div className="flex flex-wrap gap-2">
+                            <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[8px] font-black uppercase tracking-widest border shadow-sm ${getAccountStatus(admin.accountStatus).color}`}>
+                              {getAccountStatus(admin.accountStatus).label}
+                            </span>
+                             <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[8px] font-black uppercase tracking-widest border shadow-sm ${getPermissionTemplate(admin.permissions).color}`}>
+                              {getPermissionTemplate(admin.permissions).name}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="pt-3 border-t border-dashed border-gray-100 flex items-center justify-between">
+                         <div className="flex flex-col">
+                            <span className="text-[8px] text-gray-400 font-black uppercase tracking-widest">Last Online</span>
+                            <span className="text-xs font-bold text-gray-900">{formatLastLogin(admin.lastLogin)}</span>
+                         </div>
+                         <div className="flex flex-col items-end">
+                            <span className="text-[8px] text-gray-400 font-black uppercase tracking-widest">Unique ID</span>
+                            <span className="text-[10px] font-mono font-bold text-gray-500 uppercase">#{admin.uid.toUpperCase()}</span>
+                         </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/Frontend/src/pages/Support.tsx
+++ b/Frontend/src/pages/Support.tsx
@@ -7,7 +7,6 @@ import {
   MessageCircleQuestion,
   Eye,
   Clock,
-  RefreshCw,
   Filter
 } from 'lucide-react';
 import StatsCard from '../components/Dashboard/StatsCard';
@@ -276,13 +275,7 @@ const Support: React.FC = () => {
               </p>
             </div>
             
-            <button 
-              onClick={() => fetchTickets()}
-              className="flex items-center gap-1.5 text-gray-600 hover:text-gray-900 font-bold bg-gray-50 border border-gray-200 px-3 py-2 rounded-lg transition-colors text-xs"
-            >
-              <RefreshCw className="h-4 w-4" />
-              <span>REFRESH DATA</span>
-            </button>
+
           </div>
 
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
@@ -399,18 +392,19 @@ const Support: React.FC = () => {
             </button>
           </div>
 
-          <div className="flex items-center gap-2 bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm">
-            <Filter className="h-4 w-4 text-gray-400" />
-            <select 
-              value={pagination.limit}
-              onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
-              className="bg-transparent text-xs font-bold text-gray-600 focus:outline-none"
-            >
-              <option value={10}>10 per page</option>
-              <option value={20}>20 per page</option>
-              <option value={50}>50 per page</option>
-            </select>
-          </div>
+            {/* Pagination Limit for Desktop */}
+            <div className="hidden md:flex items-center gap-2 md:order-3 shrink-0">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+              <select 
+                value={pagination.limit}
+                onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
         </div>
       </div>
 

--- a/Frontend/src/pages/Transactions.tsx
+++ b/Frontend/src/pages/Transactions.tsx
@@ -11,7 +11,12 @@ import {
   Calendar,
   AlertTriangle,
   RefreshCw,
-  Wallet as WalletIcon
+  Wallet as WalletIcon,
+  LayoutGrid,
+  Table2,
+  ChevronRight,
+  MapPin,
+  Briefcase
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 
@@ -63,6 +68,7 @@ const Transactions: React.FC = () => {
     total: 0,
     pages: 0
   });
+  const [mobileViewType, setMobileViewType] = useState<'card' | 'table'>('card');
 
   // Handle query parameters when URL changes
   useEffect(() => {
@@ -148,7 +154,11 @@ const Transactions: React.FC = () => {
 
   const updateTransactionStatus = async (transactionId: string, status: string) => {
     try {
-      await mutations.updateTransactionStatus.mutateAsync({ transactionId, status });
+      await mutations.updateTransactionStatus.mutateAsync({ 
+        transactionId, 
+        status, 
+        type: transactionType 
+      });
     } catch (error) {
       console.error('Failed to update transaction status:', error);
     }
@@ -221,14 +231,7 @@ const Transactions: React.FC = () => {
           </div>
 
           <div className="flex items-center gap-4 text-xs">
-            <button
-              onClick={() => refetch()}
-              disabled={loading}
-              className="flex items-center gap-1.5 text-gray-600 hover:text-gray-900 font-bold bg-gray-50 border border-gray-200 px-3 py-2 rounded-lg transition-colors"
-            >
-              <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
-              <span>REFRESH DATA</span>
-            </button>
+
           </div>
         </div>
 
@@ -325,36 +328,54 @@ const Transactions: React.FC = () => {
            )}
         </div>
 
-        {/* Filters */}
-        <div className="space-y-3">
-          <div className="flex flex-col md:flex-row gap-3">
-            <div className="flex-1 flex gap-2">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 md:h-5 w-4 md:w-5" />
-                <input
-                  type="text"
-                  placeholder="Search transactions..."
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                  className="w-full pl-9 md:pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm font-medium"
-                />
-              </div>
-
-              <DateRangePicker
-                startDate={dateFrom}
-                endDate={dateTo}
-                onStartDateChange={setDateFrom}
-                onEndDateChange={setDateTo}
-                onClear={clearDateRange}
+        {/* Filter Bar */}
+        <div className="px-4 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row md:items-center gap-3 md:gap-6">
+          {/* Row 1 on Mobile / Search on Desktop */}
+          <div className="flex items-center gap-2 md:contents">
+            <div className="relative flex-1 md:order-1">
+              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <input
+                type="text"
+                placeholder="Search transactions..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm h-10"
               />
             </div>
 
-            <div className="flex gap-2 w-full md:w-auto overflow-x-auto pb-1 md:pb-0">
+            {/* Mobile-only Limit */}
+            <div className="flex md:hidden items-center gap-1.5 px-2">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Limit</span>
+              <select 
+                value={pagination.limit}
+                onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                className="bg-transparent border-none text-xs font-black text-gray-600 focus:outline-none focus:ring-0 cursor-pointer pr-8"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
+          </div>
+
+          {/* Row 2 on Mobile / Desktop Right-side group */}
+          <div className="flex items-center justify-between gap-3 md:flex-initial md:order-2 md:justify-end md:gap-6 shrink-0">
+            <div className="flex-1 md:flex-initial flex items-center gap-2 overflow-x-auto no-scrollbar pb-0.5 md:pb-0">
+              <div className="shrink-0">
+                <DateRangePicker
+                  startDate={dateFrom}
+                  endDate={dateTo}
+                  onStartDateChange={setDateFrom}
+                  onEndDateChange={setDateTo}
+                  onClear={clearDateRange}
+                />
+              </div>
+
               {category !== 'platform_fee' && category !== 'wallet_topup' && category !== 'withdrawal' && category !== 'refund_request' && (
                 <select
                   value={statusFilter}
                   onChange={(e) => setStatusFilter(e.target.value)}
-                  className="flex-1 md:flex-none px-3 md:px-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm font-bold uppercase tracking-wider"
+                  className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-black uppercase tracking-wider text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 md:min-w-[120px]"
                 >
                   <option value="all">ALL STATUS</option>
                   <option value="pending">PENDING</option>
@@ -367,13 +388,43 @@ const Transactions: React.FC = () => {
               <select
                 value={paymentMethodFilter}
                 onChange={(e) => setPaymentMethodFilter(e.target.value)}
-                className="flex-1 md:flex-none hidden md:block px-3 md:px-4 py-2 bg-white border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm font-bold uppercase tracking-wider"
+                className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-black uppercase tracking-wider text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 md:min-w-[120px]"
               >
                 <option value="all">ALL METHODS</option>
                 <option value="wallet">WALLET</option>
                 <option value="cash">CASH</option>
                 <option value="xendit">XENDIT</option>
               </select>
+            </div>
+
+            {/* Pagination Limit for Desktop */}
+            <div className="hidden md:flex items-center gap-2 md:order-3 shrink-0">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+              <select 
+                value={pagination.limit}
+                onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
+
+            {/* View Type Toggle - Mobile only */}
+            <div className="flex md:hidden items-center bg-white border border-gray-200 rounded-[12px] p-1 shadow-sm shrink-0 md:order-4">
+               <button
+                 onClick={() => setMobileViewType('card')}
+                 className={`p-1.5 rounded-[10px] transition-all ${mobileViewType === 'card' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+               >
+                 <LayoutGrid className="h-3.5 w-3.5" />
+               </button>
+               <button
+                 onClick={() => setMobileViewType('table')}
+                 className={`p-1.5 rounded-[10px] transition-all ${mobileViewType === 'table' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+               >
+                 <Table2 className="h-3.5 w-3.5" />
+               </button>
             </div>
           </div>
         </div>
@@ -439,8 +490,8 @@ const Transactions: React.FC = () => {
                         >
                           <td className="px-6 py-4 border-b border-gray-300">
                             <div className="flex items-start gap-4">
-                              <div className="p-2 rounded-xl bg-gray-50 group-hover:bg-white transition-colors border border-gray-100 items-center justify-center flex">
-                                {getTransactionIcon(transaction.type, transaction.transactionType)}
+                              <div className="w-11 h-11 rounded-xl bg-gray-50 group-hover:bg-white transition-colors border border-gray-100 items-center justify-center flex flex-shrink-0">
+                                {getTransactionIcon(transaction)}
                               </div>
                               <div className="min-w-0 flex-1">
                                 <div className="flex items-center gap-2 mb-1">
@@ -531,7 +582,9 @@ const Transactions: React.FC = () => {
               </div>
 
               {/* Mobile View */}
-              <div className="md:hidden flex-1 overflow-y-auto px-4 py-4 space-y-4">
+              <div className="md:hidden flex-1 flex flex-col min-h-0 bg-gray-50/30">
+                {mobileViewType === 'card' ? (
+                  <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
                 {transactions.map((transaction) => {
                   const user = getUser(transaction);
                   return (
@@ -557,8 +610,8 @@ const Transactions: React.FC = () => {
                       
                       <div className="p-4">
                         <div className="flex items-start gap-3">
-                          <div className="p-2.5 rounded-xl bg-gray-50 border border-gray-100">
-                            {getTransactionIcon(transaction.type, transaction.transactionType)}
+                          <div className="w-11 h-11 rounded-xl bg-gray-50 border border-gray-100 flex items-center justify-center flex-shrink-0">
+                            {getTransactionIcon(transaction)}
                           </div>
                           <div className="flex-1 min-w-0">
                             <p className="text-sm font-black text-gray-900 leading-tight mb-1">
@@ -594,9 +647,60 @@ const Transactions: React.FC = () => {
                   );
                 })}
               </div>
-            </>
-          )}
-        </div>
+            ) : (
+                <div className="flex-1 overflow-x-hidden">
+                  <table className="w-full table-fixed border-separate border-spacing-0">
+                    <thead className="bg-gray-50/80 sticky top-0 z-20">
+                      <tr>
+                        <th className="w-[60%] px-3 py-2.5 text-left text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100 uppercase">Transact</th>
+                        <th className="w-[15%] px-1 py-2.5 text-center text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100 uppercase">Stat</th>
+                        <th className="w-[25%] px-3 py-2.5 text-right text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100 uppercase">Amt</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {transactions.map((transaction) => (
+                        <tr 
+                          key={transaction._id} 
+                          onClick={() => openTransactionModal(transaction)}
+                          className="border-b border-gray-100 active:bg-gray-50 transition-colors"
+                        >
+                          <td className="px-3 py-4 overflow-hidden">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <div className="h-7 w-7 rounded-lg bg-gray-50 flex items-center justify-center flex-shrink-0 border border-gray-100 shadow-sm">
+                                {React.cloneElement(getTransactionIcon(transaction) as React.ReactElement, { className: 'h-3.5 w-3.5' })}
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <p className="text-[11px] font-black text-gray-900 truncate leading-tight">
+                                  {transaction._id.slice(-8).toUpperCase()}
+                                </p>
+                                <p className="text-[10px] text-gray-400 font-bold truncate uppercase tracking-tighter">
+                                  {transaction.type?.replace('_', ' ')}
+                                </p>
+                              </div>
+                            </div>
+                          </td>
+                          <td className="px-1 py-4 text-center">
+                            <div className={`w-1.5 h-1.5 rounded-full mx-auto ${
+                              transaction.status === 'completed' ? 'bg-green-500' : 
+                              transaction.status === 'pending' ? 'bg-yellow-500' : 'bg-red-500'
+                            }`} />
+                          </td>
+                          <td className="px-3 py-4 text-right">
+                             <p className="text-[11px] font-black text-gray-900 leading-none mb-1">
+                               {formatPHPCurrency(transaction.amount)}
+                             </p>
+                             <p className="text-[9px] text-gray-400 font-bold uppercase tracking-widest">{transaction.paymentMethod}</p>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
 
         {/* Pagination Toolbar */}
         {pagination.pages > 1 && (

--- a/Frontend/src/pages/Users.tsx
+++ b/Frontend/src/pages/Users.tsx
@@ -7,11 +7,12 @@ import {
   CheckCircle,
   XCircle,
   Users as UsersIcon,
-  RefreshCw,
   ChevronRight,
   Shield,
   Clock,
   Ban,
+  LayoutGrid,
+  Table2
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { UserDetailsModal } from '../components/Modals';
@@ -44,6 +45,7 @@ const Users: React.FC = () => {
     total: 0,
     pages: 0
   });
+  const [mobileViewType, setMobileViewType] = useState<'card' | 'table'>('card');
 
   const getUserType = () => {
     const path = location.pathname;
@@ -60,7 +62,7 @@ const Users: React.FC = () => {
     if (type === 'providers') return 'Service Providers';
     if (type === 'flagged') return 'Flagged & Suspended Users';
     if (type === 'deleted') return 'Deleted Accounts';
-    return 'Users Management';
+    return 'All Users';
   };
 
   const getPageDescription = () => {
@@ -116,7 +118,8 @@ const Users: React.FC = () => {
     userType === 'customers' ? { userType: 'client' } :
       userType === 'providers' ? { userType: 'provider' } :
         userType === 'flagged' ? { accountStatus: 'restricted,suspended,banned' } :
-          {}
+          userType === 'deleted' ? { accountStatus: 'deleted' } :
+            {}
   );
   const { data: flaggedUserCounts = { total: 0, suspended: 0, restricted: 0, banned: 0, providers: 0, customers: 0 } } = useFlaggedUserCounts();
   const { data: deletedUserCounts = { total: 0, customers: 0, providers: 0 } } = useDeletedUserCounts();
@@ -284,11 +287,11 @@ const Users: React.FC = () => {
   };
 
   return (
-    <div className="fixed inset-0 md:left-72 flex flex-col bg-gray-50 mt-16 md:mt-0 h-screen overflow-hidden">
+    <div className="fixed top-16 md:top-0 bottom-0 left-0 md:left-72 right-0 flex flex-col bg-gray-50 overflow-hidden">
       {/* Header Section */}
       <div className="flex-shrink-0 bg-white border-b border-gray-200 z-30 shadow-sm relative">
         <div className="px-6 py-5">
-          <div className="flex items-center justify-between mb-6">
+          <div className="hidden md:flex items-center justify-between mb-6">
             <div>
               <div className="flex items-center gap-2 mb-1">
                 <span className="p-1.5 bg-blue-50 rounded-lg">
@@ -301,13 +304,7 @@ const Users: React.FC = () => {
               <p className="text-xs text-gray-500 font-medium">{getPageDescription()}</p>
             </div>
             
-            <button 
-              onClick={() => refetch()}
-              className="flex items-center gap-1.5 text-gray-600 hover:text-gray-900 font-bold bg-gray-50 border border-gray-200 px-3 py-2 rounded-lg transition-colors text-xs"
-            >
-              <RefreshCw className="h-4 w-4" />
-              <span>REFRESH DATA</span>
-            </button>
+
           </div>
 
           {/* Stats Cards Grid */}
@@ -514,71 +511,107 @@ const Users: React.FC = () => {
         </div>
 
         {/* Filter Bar */}
-        <div className="px-6 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row items-center gap-4">
-          <div className="relative flex-1">
-            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
-            <input
-              type="text"
-              placeholder="Search by name or email..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm"
-            />
-          </div>
+        <div className="px-4 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col lg:flex-row lg:items-center gap-3 lg:gap-6">
+          {/* Row 1 on Mobile / Part 1 on Desktop: Search and Limit */}
+          <div className="flex items-center gap-2 lg:contents">
+            <div className="relative flex-1 lg:order-1">
+              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <input
+                type="text"
+                placeholder="Search..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm h-10"
+              />
+            </div>
 
-          <div className="flex items-center gap-2">
-            {userType === 'providers' ? (
-              <div className="flex items-center gap-2 px-1">
-                <span className="text-xs font-bold text-gray-400">Profession:</span>
-                <select 
-                  value={professionFilter}
-                  onChange={(e) => {
-                    setProfessionFilter(e.target.value);
-                    setPagination(prev => ({ ...prev, page: 1 }));
-                  }}
-                  className="bg-white border border-gray-200 rounded-xl px-3 py-1.5 text-xs font-bold text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 min-w-[140px] shadow-sm transition-all hover:border-gray-300"
-                >
-                  <option value="all">All Professions</option>
-                  {professionsList.map(prof => (
-                    <option key={prof} value={prof} className="capitalize">{prof}</option>
-                  ))}
-                </select>
-              </div>
-            ) : (
-              [
-                { key: 'all', label: 'All', count: statusCounts.all },
-                { key: 'verified', label: 'Verified', count: statusCounts.verified },
-                { key: 'unverified', label: 'Unverified', count: statusCounts.unverified }
-              ].map((tab) => (
-                <button
-                  key={tab.key}
-                  onClick={() => {
-                    setStatusFilter(tab.key as any);
-                    setPagination(prev => ({ ...prev, page: 1 }));
-                  }}
-                  className={`px-3 py-2 text-xs font-bold rounded-xl transition-all border ${statusFilter === tab.key
-                    ? 'bg-blue-600 text-white border-blue-600 shadow-sm'
-                    : 'bg-white text-gray-600 border-gray-200 hover:bg-gray-50'
-                    }`}
-                >
-                  {tab.label} ({tab.count})
-                </button>
-              ))
-            )}
-            
-            <div className="h-6 w-px bg-gray-200 mx-1" />
-
-            <div className="flex items-center gap-2 px-1">
-              <span className="text-xs font-bold text-gray-400">Limit:</span>
+            <div className="flex lg:hidden items-center gap-1.5 px-2">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
                 onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
-                className="bg-white border border-gray-200 rounded-xl px-3 py-1.5 text-xs font-bold text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 shadow-sm transition-all hover:border-gray-300"
+                className="bg-transparent text-xs font-black text-gray-600 focus:outline-none cursor-pointer"
               >
                 <option value={10}>10</option>
                 <option value={20}>20</option>
                 <option value={50}>50</option>
               </select>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-3 lg:flex-initial lg:order-2 lg:justify-end lg:gap-6 shrink-0">
+            <div className={`flex-1 flex items-center gap-1 lg:flex-initial lg:justify-end ${userType === 'providers' ? 'overflow-hidden' : 'overflow-x-auto no-scrollbar pb-0.5'}`}>
+              {userType === 'providers' ? (
+                <div className="flex-1 lg:flex-initial flex items-center gap-1.5">
+                  <select 
+                    value={professionFilter}
+                    onChange={(e) => {
+                      setProfessionFilter(e.target.value);
+                      setPagination(prev => ({ ...prev, page: 1 }));
+                    }}
+                    className="flex-1 lg:flex-initial bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-black uppercase tracking-wider text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 lg:min-w-[140px] lg:max-w-[160px] truncate"
+                  >
+                    <option value="all">Professions</option>
+                    {professionsList.map(prof => (
+                      <option key={prof} value={prof} className="capitalize">{prof}</option>
+                    ))}
+                  </select>
+                </div>
+              ) : (
+                <div className="flex items-center gap-1 min-w-max">
+                  {[
+                    { key: 'all', label: 'All', count: statusCounts.all },
+                    { key: 'verified', label: 'Verified', count: statusCounts.verified },
+                    { key: 'unverified', label: 'Unverified', count: statusCounts.unverified }
+                  ].map((tab) => (
+                    <button
+                      key={tab.key}
+                      onClick={() => {
+                        setStatusFilter(tab.key as any);
+                        setPagination(prev => ({ ...prev, page: 1 }));
+                      }}
+                      className={`px-2.5 py-2 text-[10px] font-black rounded-xl transition-all border uppercase tracking-widest ${statusFilter === tab.key
+                        ? 'bg-blue-600 text-white border-blue-600 shadow-sm'
+                        : 'bg-white text-gray-600 border-gray-200'
+                        }`}
+                    >
+                      {tab.label} ({tab.count})
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Pagination Limit for Desktop */}
+            <div className="hidden lg:flex items-center gap-2 order-3 shrink-0">
+               <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+               <select 
+                 value={pagination.limit}
+                 onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                 className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+               >
+                 <option value={10}>10</option>
+                 <option value={20}>20</option>
+                 <option value={50}>50</option>
+               </select>
+            </div>
+
+            {/* View Type Toggle - Mobile only */}
+            <div className="lg:hidden flex items-center bg-white border border-gray-200 rounded-xl p-1 shadow-sm shrink-0">
+              <button
+                onClick={() => setMobileViewType('card')}
+                className={`p-1.5 rounded-lg transition-all ${mobileViewType === 'card' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+                title="Card View"
+              >
+                <LayoutGrid className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => setMobileViewType('table')}
+                className={`p-1.5 rounded-lg transition-all ${mobileViewType === 'table' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+                title="Table View"
+              >
+                <Table2 className="h-4 w-4" />
+              </button>
             </div>
           </div>
         </div>
@@ -602,7 +635,7 @@ const Users: React.FC = () => {
           ) : (
             <>
               {/* Desktop View */}
-              <div className="hidden lg:block bg-white flex-1 relative overflow-hidden">
+              <div className="hidden lg:block bg-white flex-1 relative">
                 <table className="min-w-full table-fixed border-separate border-spacing-0">
                   <thead className="bg-gray-50/80 backdrop-blur-md sticky top-0 z-20">
                     <tr className="border-b border-gray-200">
@@ -699,7 +732,7 @@ const Users: React.FC = () => {
                                           }}
                                         />
                                       </div>
-                                      <span className="text-[9.5px] font-bold text-indigo-600 uppercase tracking-tight text-center leading-tight max-w-[100px]">
+                                      <span className="text-[9.5px] font-bold text-gray-900 uppercase tracking-tight text-center leading-tight max-w-[100px]">
                                         {label}
                                       </span>
                                     </div>
@@ -743,97 +776,141 @@ const Users: React.FC = () => {
               </div>
 
               {/* Mobile View */}
-              <div className="lg:hidden flex-1 overflow-y-auto px-4 py-4 space-y-4">
-                {users.map((user) => (
-                  <div
-                    key={user._id}
-                    onClick={() => openDetailsModal(user)}
-                    className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden active:scale-[0.98] transition-all"
-                  >
-                    <div className="flex items-center justify-between px-4 py-2.5 bg-gray-50/80 border-b border-gray-100">
-                       <span className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">
-                         {formatDistanceToNow(new Date(user.createdAt), { addSuffix: true })}
-                       </span>
-                    </div>
-
-                    <div className="p-4">
-                       <div className="flex items-center gap-4 mb-4">
-                        <div className="relative flex-shrink-0">
-                          {user.profileImage ? (
-                            <img src={user.profileImage} className="h-12 w-12 rounded-full border border-gray-100 bg-white" alt="" />
-                          ) : (
-                            <div className="h-12 w-12 rounded-full bg-blue-50 flex items-center justify-center border border-blue-100">
-                              <span className="text-xs font-black text-blue-600">{getInitials(user.name)}</span>
-                            </div>
-                          )}
-                          {user.isOnline && <div className="absolute bottom-0 right-0 w-3 h-3 bg-green-500 border-2 border-white rounded-full"></div>}
+              <div className="lg:hidden flex-1 overflow-y-auto">
+                {mobileViewType === 'card' ? (
+                  <div className="px-4 py-4 space-y-4">
+                    {users.map((user) => (
+                      <div
+                        key={user._id}
+                        onClick={() => openDetailsModal(user)}
+                        className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden active:scale-[0.98] transition-all"
+                      >
+                        <div className="flex items-center justify-between px-4 py-2.5 bg-gray-50/80 border-b border-gray-100">
+                           <span className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">
+                             {formatDistanceToNow(new Date(user.createdAt), { addSuffix: true })}
+                           </span>
+                           <div className="flex items-center gap-1.5">
+                              {getStatusLabel(user) ? (
+                                <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[8px] font-black uppercase tracking-wider border ${getStatusColor(user)}`}>
+                                  {getStatusLabel(user)}
+                                </span>
+                              ) : (
+                                <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[8px] font-black uppercase tracking-wider border ${user.isVerified ? 'bg-emerald-50 text-emerald-700 border-emerald-100' : 'bg-amber-50 text-amber-700 border-amber-100'}`}>
+                                  {user.isVerified ? 'Verified' : 'Unverified'}
+                                </span>
+                              )}
+                           </div>
                         </div>
-                         <div className="flex-1 min-w-0">
-                           <div className="flex items-center gap-2 mb-1">
-                             <h3 className="text-base font-black text-gray-900 leading-tight truncate">{user.name}</h3>
-                             <span className={`text-[8px] font-black uppercase tracking-widest px-1.5 py-0.5 rounded border ${user.userType === 'provider' ? 'bg-indigo-50 text-indigo-700 border-indigo-100' : 'bg-purple-50 text-purple-700 border-purple-100'}`}>
-                               {user.userType}
-                             </span>
-                           </div>
-                           <div className="flex items-center gap-2">
-                             <p className="text-xs text-gray-500 truncate">{user.email || user.phone}</p>
-                             {user.userType === 'provider' && (
-                               (() => {
-                                 const professions = getProviderProfessions(user);
-                                 if (professions.length === 0) return null;
-                                 
-                                 return (
-                                   <div className="flex flex-wrap gap-1 mt-1">
-                                     {professions.map((prof, idx) => {
-                                                                               const iconData = resolveIconForProfession(prof, categories);
-                                       const label = (iconData?.label && iconData.label !== 'Professional Services')
-                                         ? iconData.label
-                                         : prof.replace(/([A-Z])/g, ' $1').replace(/_/g, ' ').trim().toUpperCase();
-                                       return (
-                                         <span key={idx} className="text-[8px] font-black text-indigo-500 uppercase tracking-widest bg-indigo-50 px-1.5 py-0.5 rounded border border-indigo-100">
-                                           {label}
-                                         </span>
-                                       );
-                                     })}
-                                   </div>
-                                 );
-                               })()
-                             )}
-                           </div>
-                         </div>
-                       </div>
 
-                       <div className="grid grid-cols-2 gap-3 pt-4 border-t border-dashed border-gray-100">
-                          <div className="flex flex-col">
-                            <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest opacity-70">Wallet balance</span>
-                            <span className="text-sm font-black text-gray-900">{formatCurrency(user.wallet?.balance || 0)}</span>
-                          </div>
-                          <div className="flex flex-col items-end">
-                            <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest opacity-70">Verification</span>
-                            <span className={`text-[10px] font-black uppercase tracking-widest ${user.isVerified ? 'text-emerald-600' : 'text-amber-600'}`}>
-                               {user.isVerified ? 'VERIFIED' : 'UNVERIFIED'}
-                            </span>
-                          </div>
-                       </div>
-                    </div>
+                        <div className="p-4">
+                           <div className="flex items-center gap-4 mb-4">
+                            <div className="relative flex-shrink-0">
+                              {user.profileImage ? (
+                                <img src={user.profileImage} className="h-12 w-12 rounded-full border border-gray-100 bg-white object-cover" alt="" />
+                              ) : (
+                                <div className="h-12 w-12 rounded-full bg-blue-50 flex items-center justify-center border border-blue-100">
+                                  <span className="text-sm font-black text-blue-600">{getInitials(user.name)}</span>
+                                </div>
+                              )}
+                              {user.isOnline && <div className="absolute bottom-0 right-0 w-3 h-3 bg-green-500 border-2 border-white rounded-full"></div>}
+                            </div>
+                             <div className="flex-1 min-w-0">
+                               <div className="flex items-center gap-2 mb-1">
+                                 <h3 className="text-base font-black text-gray-900 leading-tight truncate">{user.name}</h3>
+                               </div>
+                               <div className="flex flex-col gap-1">
+                                 <p className="text-xs text-gray-500 truncate">{user.email || user.phone}</p>
+                                 <div className="flex items-center gap-2">
+                                   <span className={`text-[8px] font-black uppercase tracking-widest px-1.5 py-0.5 rounded border ${user.userType === 'provider' ? 'bg-indigo-50 text-indigo-700 border-indigo-100' : 'bg-purple-50 text-purple-700 border-purple-100'}`}>
+                                     {user.userType}
+                                   </span>
+                                   {user.userType === 'provider' && getProviderProfessions(user).length > 0 && (
+                                     <span className="text-[8px] font-black text-indigo-500 uppercase tracking-widest bg-indigo-50 px-1.5 py-0.5 rounded border border-indigo-100">
+                                       {getProviderProfessions(user)[0]}
+                                     </span>
+                                   )}
+                                 </div>
+                               </div>
+                             </div>
+                           </div>
 
-                    <div className="px-4 py-3 bg-gray-50/50 border-t border-gray-100 flex items-center justify-between">
-                       <div className="flex items-center gap-2 text-[9px] font-black text-gray-400 uppercase tracking-widest">
-                         <Shield className="h-3 w-3" />
-                         ID: {user._id.slice(-8).toUpperCase()}
-                       </div>
-                       <ChevronRight className="h-4 w-4 text-gray-300" />
-                    </div>
+                           <div className="grid grid-cols-2 gap-3 pt-4 border-t border-dashed border-gray-100">
+                              <div className="flex flex-col">
+                                <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest">Balance</span>
+                                <span className="text-sm font-black text-gray-900">{formatCurrency(user.wallet?.balance || 0)}</span>
+                              </div>
+                              <div className="flex flex-col items-end text-right">
+                                <span className="text-[9px] text-gray-400 font-black uppercase tracking-widest">Action</span>
+                                <button className="text-[10px] font-black text-blue-600 uppercase tracking-widest flex items-center gap-1">
+                                  Profile <ChevronRight className="h-3 w-3" />
+                                </button>
+                              </div>
+                           </div>
+                        </div>
+                      </div>
+                    ))}
                   </div>
-                ))}
+                ) : (
+                  <div className="bg-white">
+                    <table className="w-full table-fixed border-separate border-spacing-0">
+                      <thead className="bg-gray-50/80 sticky top-0 z-20">
+                        <tr>
+                          <th className="w-[50%] px-3 py-3 text-left text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">User</th>
+                          <th className="w-[25%] px-2 py-3 text-center text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Type</th>
+                          <th className="w-[25%] px-3 py-3 text-right text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-50">
+                        {users.map((user) => (
+                          <tr 
+                            key={user._id} 
+                            onClick={() => openDetailsModal(user)}
+                            className="active:bg-gray-50 transition-colors"
+                          >
+                            <td className="px-3 py-3 overflow-hidden">
+                              <div className="flex items-center gap-2 min-w-0">
+                                {user.profileImage ? (
+                                  <img src={user.profileImage} className="h-8 w-8 rounded-full border border-gray-100 object-cover flex-shrink-0" alt="" />
+                                ) : (
+                                  <div className="h-8 w-8 rounded-full bg-blue-50 flex items-center justify-center border border-blue-100 flex-shrink-0">
+                                    <span className="text-[10px] font-black text-blue-600">{getInitials(user.name)}</span>
+                                  </div>
+                                )}
+                                <div className="min-w-0 flex-1">
+                                  <p className="text-[11px] font-black text-gray-900 truncate leading-tight">{user.name}</p>
+                                  <p className="text-[9px] text-gray-400 font-bold truncate uppercase">{user.userType}</p>
+                                </div>
+                              </div>
+                            </td>
+                            <td className="px-2 py-3 text-center">
+                              <span className={`inline-flex px-1.5 py-0.5 rounded text-[8px] font-black uppercase tracking-tight border ${user.userType === 'provider' ? 'bg-indigo-50 text-indigo-600 border-indigo-100' : 'bg-purple-50 text-purple-600 border-purple-100'}`}>
+                                {user.userType || 'Unknown'}
+                              </span>
+                            </td>
+                            <td className="px-3 py-3 text-right">
+                              {getStatusLabel(user) ? (
+                                <span className={`inline-flex px-1.5 py-0.5 rounded text-[8px] font-black uppercase tracking-tight border ${getStatusColor(user)}`}>
+                                  {getStatusLabel(user).split(' ')[0]}
+                                </span>
+                              ) : (
+                                <span className={`inline-flex px-1.5 py-0.5 rounded text-[8px] font-black uppercase tracking-tight border ${user.isVerified ? 'bg-emerald-50 text-emerald-600 border-emerald-100' : 'bg-amber-50 text-amber-600 border-amber-100'}`}>
+                                  {user.isVerified ? 'VER' : 'UNV'}
+                                </span>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
               </div>
-
             </>
           )}
         </div>
 
         {!loading && users.length > 0 && (
-          <div className="flex-shrink-0 bg-white border-t border-gray-200 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)] z-10 p-4">
+          <div className="flex-shrink-0 bg-white border-t border-gray-200 z-10 p-4">
             <div className="flex items-center justify-between w-full">
               <div>
                 <p className="text-xs md:text-sm text-gray-700">

--- a/Frontend/src/pages/Verifications.tsx
+++ b/Frontend/src/pages/Verifications.tsx
@@ -292,13 +292,7 @@ const Verifications: React.FC = () => {
               </p>
             </div>
             
-            <button 
-              onClick={() => refetch()}
-              className="flex items-center gap-1.5 text-gray-600 hover:text-gray-900 font-bold bg-gray-50 border border-gray-200 px-3 py-2 rounded-lg transition-colors text-xs"
-            >
-              <RefreshCw className="h-4 w-4" />
-              <span>REFRESH DATA</span>
-            </button>
+
           </div>
 
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
@@ -394,16 +388,16 @@ const Verifications: React.FC = () => {
             </button>
           </div>
 
-          <div className="flex items-center gap-2 bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm">
-            <Filter className="h-4 w-4 text-gray-400" />
+          <div className="hidden md:flex items-center gap-2 shrink-0">
+            <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
             <select 
               value={pagination.limit}
               onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
-              className="bg-transparent text-xs font-bold text-gray-600 focus:outline-none"
+              className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
             >
-              <option value={10}>10 per page</option>
-              <option value={20}>20 per page</option>
-              <option value={50}>50 per page</option>
+              <option value={10}>10</option>
+              <option value={20}>20</option>
+              <option value={50}>50</option>
             </select>
           </div>
         </div>

--- a/Frontend/src/utils/transactionHelpers.tsx
+++ b/Frontend/src/utils/transactionHelpers.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   CheckCircle,
   XCircle,
@@ -9,6 +8,7 @@ import {
   DollarSign
 } from 'lucide-react';
 import type { Transaction } from '../types';
+import { getProfessionIconFromName } from '../constants/categoryIcons';
 
 /**
  * Transaction utility helper functions
@@ -82,9 +82,33 @@ export const getTransactionStatusIcon = (status: string): JSX.Element | null => 
 /**
  * Get transaction icon based on type
  */
-export const getTransactionIcon = (type: string, transactionType: string): JSX.Element => {
-  if (transactionType === 'platform_fee') {
-    return <DollarSign className="h-4 w-4" />;
+export const getTransactionIcon = (transaction: any): JSX.Element => {
+  const { type, transactionType, jobId, job } = transaction;
+  const jobInfo = jobId || job;
+
+  if (transactionType === 'platform_fee' || type === 'platform_fee') {
+    // If we have job information, try to get the profession icon
+    if (jobInfo?.category || jobInfo?.title) {
+      const iconData = getProfessionIconFromName(jobInfo.category || jobInfo.title);
+      
+      if (iconData?.imagePath) {
+        return (
+          <div className="w-8 h-8 flex items-center justify-center">
+            <img 
+              src={iconData.imagePath} 
+              alt={jobInfo.category || jobInfo.title} 
+              className="w-full h-full object-contain"
+              onError={(e) => {
+                // Fallback to DollarSign if image fails
+                const target = e.target as HTMLImageElement;
+                target.style.display = 'none';
+              }}
+            />
+          </div>
+        );
+      }
+    }
+    return <DollarSign className="h-5 w-5 text-yellow-600" />;
   }
 
   switch (type) {
@@ -96,7 +120,6 @@ export const getTransactionIcon = (type: string, transactionType: string): JSX.E
     case 'xendit_topup':
       return <ArrowDownLeft className="h-4 w-4" />;
     case 'fee_payment':
-    case 'platform_fee':
       return <DollarSign className="h-4 w-4" />;
     case 'refund':
       return <ArrowDownLeft className="h-4 w-4" />;


### PR DESCRIPTION
Backend: Treat revenue as platform_fee (filter Transaction queries by type), add debug logging in authController, remove hardcoded dbName from mongoose connect, expose io/getIO and store global.io for fallback emits, enable direct socket emits and add graceful change stream error handling/fallback messaging. Frontend: enhance StatsCard with subtitle, compact/horizontal mobile layouts and responsive tweaks; update App route title for Jobs; improve Layout section descriptions. Modals: move JobDetailsModal into a portal, major UI/layout overhaul (media, applicants, profile, action buttons), and add SidebarContext usage to hide header while modals are open across Job, Transaction, User, and Verification modals. Settings: enable transactions/support permissions for admin create/edit flows and update role description. Hooks: useTransactions now returns amount aggregates and mutation payloads updated to include type. Misc: minor UI/UX polish and console/log improvements.