### PR TITLE
feat: Add profession icons & mobile page-limit UI

### DIFF
--- a/Backend/app/controllers/transactionController.js
+++ b/Backend/app/controllers/transactionController.js
@@ -75,7 +75,7 @@ const getTransactions = async (req, res) => {
       .populate('toUserId', 'name email phone location profileImage')
       .populate({
         path: 'jobId',
-        select: 'title category userId assignedToId budget',
+        select: 'title category categoryName professionName icon userId assignedToId budget',
         populate: [
           {
             path: 'userId',
@@ -162,7 +162,7 @@ const getTransactions = async (req, res) => {
         })
         .populate({
           path: 'jobId',
-          select: 'title category userId assignedToId budget',
+          select: 'title category categoryName professionName icon userId assignedToId budget',
           populate: [
             {
               path: 'userId',
@@ -283,7 +283,7 @@ const getTransactionDetails = async (req, res) => {
         })
         .populate({
           path: 'jobId',
-          select: 'title description category userId assignedToId budget',
+          select: 'title description category categoryName professionName icon userId assignedToId budget',
           populate: [
             {
               path: 'userId',
@@ -350,7 +350,7 @@ const getTransactionDetails = async (req, res) => {
         .populate('toUserId', 'name email phone location profileImage')
         .populate({
           path: 'jobId',
-          select: 'title description category userId assignedToId budget',
+          select: 'title description category categoryName professionName icon userId assignedToId budget',
           populate: [
             {
               path: 'userId',
@@ -426,7 +426,7 @@ const updateTransactionStatus = async (req, res) => {
       .populate('toUser', 'name email phone location')
       .populate('fromUserId', 'name email phone location')
       .populate('toUserId', 'name email phone location')
-      .populate('jobId', 'title category')
+      .populate('jobId', 'title category categoryName professionName icon')
       .lean();
       
       if (updatedTransaction) {
@@ -505,7 +505,7 @@ const updateTransactionStatus = async (req, res) => {
     .populate('toUserId', 'name email phone location')
     .populate({
       path: 'jobId',
-      select: 'title category userId assignedToId budget',
+      select: 'title category categoryName professionName icon userId assignedToId budget',
       populate: [
         {
           path: 'userId',

--- a/Frontend/src/components/Modals/JobDetailsModal.tsx
+++ b/Frontend/src/components/Modals/JobDetailsModal.tsx
@@ -333,7 +333,11 @@ const JobDetailsModal: React.FC<JobDetailsModalProps> = ({
                     <span className="text-[9px] font-black uppercase tracking-widest">Profession</span>
                   </div>
                   <p className="text-sm font-bold text-gray-900 capitalize">
-                    {(job.category || '').replace(/([A-Z])/g, ' $1').trim()}
+                    {(() => {
+                      const val = ((job as any).professionName || (job as any).categoryName || job.category || '').trim();
+                      if (/^[a-fA-F0-9]{24}$/.test(val)) return 'General Service';
+                      return val.replace(/([A-Z])/g, ' $1').trim();
+                    })()}
                   </p>
                 </div>
 

--- a/Frontend/src/components/Modals/TopUpModal.tsx
+++ b/Frontend/src/components/Modals/TopUpModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { createPortal } from 'react-dom';
 import { X as XIcon } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import type { Transaction } from '../../types';
@@ -12,7 +13,7 @@ interface TopUpModalProps {
 }
 
 const TopUpModal: React.FC<TopUpModalProps> = ({ isOpen, onClose, transaction, onStatusUpdate }) => {
-  if (!isOpen || !transaction) return null;
+  if (!transaction) return null;
 
   const formatCurrency = (amount: number) => {
     return formatPHPCurrency(amount, {
@@ -23,12 +24,12 @@ const TopUpModal: React.FC<TopUpModalProps> = ({ isOpen, onClose, transaction, o
 
   const customer = getUser(transaction);
 
-  return (
+  return createPortal(
     <>
-      <div className="fixed inset-0 bg-black bg-opacity-50 z-40 transition-opacity" onClick={onClose} />
+      <div className="fixed inset-0 bg-black bg-opacity-50 z-[100] transition-opacity" onClick={onClose} />
 
       <div
-        className={`fixed top-0 right-0 h-full w-full md:w-[600px] bg-white shadow-2xl z-50 transform transition-transform duration-300 ${isOpen ? 'translate-x-0' : 'translate-x-full'
+        className={`fixed top-0 right-0 h-full w-full md:w-[600px] bg-white shadow-2xl z-[101] transform transition-transform duration-300 ${isOpen ? 'translate-x-0' : 'translate-x-full'
           }`}
       >
         <div className="h-full flex flex-col">
@@ -162,7 +163,8 @@ const TopUpModal: React.FC<TopUpModalProps> = ({ isOpen, onClose, transaction, o
           </div>
         </div>
       </div>
-    </>
+    </>,
+    document.body
   );
 };
 

--- a/Frontend/src/components/Modals/TransactionDetailsModal.tsx
+++ b/Frontend/src/components/Modals/TransactionDetailsModal.tsx
@@ -35,7 +35,7 @@ const TransactionDetailsModal: React.FC<TransactionDetailsModalProps> = ({
     };
   }, [isOpen, setIsHeaderHidden]);
 
-  if (!isOpen || !transaction) return null;
+  if (!transaction) return null;
 
   const formatCurrency = (amount: number) => {
     return formatPHPCurrency(amount, {

--- a/Frontend/src/pages/Activity.tsx
+++ b/Frontend/src/pages/Activity.tsx
@@ -516,6 +516,20 @@ const Activity: React.FC = () => {
               </select>
             </div>
 
+            {/* Mobile-only Limit */}
+            <div className="flex md:hidden items-center gap-1.5">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+              <select 
+                value={pagination.limit}
+                onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
+
             <div className="hidden md:flex items-center gap-2 md:order-3 shrink-0">
               <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 

--- a/Frontend/src/pages/ArchivedJobs.tsx
+++ b/Frontend/src/pages/ArchivedJobs.tsx
@@ -305,12 +305,12 @@ const ArchivedJobs: React.FC = () => {
             </div>
 
             {/* Mobile-only Limit */}
-            <div className="flex md:hidden items-center gap-1.5 px-2">
+            <div className="flex md:hidden items-center gap-1.5">
               <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
                 onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
-                className="bg-transparent border-none text-xs font-black text-gray-600 focus:outline-none focus:ring-0 cursor-pointer pr-8"
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
               >
                 <option value={10}>10</option>
                 <option value={20}>20</option>

--- a/Frontend/src/pages/Flagged.tsx
+++ b/Frontend/src/pages/Flagged.tsx
@@ -311,6 +311,19 @@ const Flagged: React.FC = () => {
               onChange={(e) => setSearchTerm(e.target.value)}
               className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm"
             />
+            {/* Mobile-only Limit */}
+            <div className="flex md:hidden items-center gap-1.5 mt-3">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+              <select 
+                value={itemsPerPage}
+                onChange={(e) => setItemsPerPage(Number(e.target.value))}
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
           </div>
 
           <div className="hidden md:flex items-center gap-2 md:order-3 shrink-0">

--- a/Frontend/src/pages/Jobs.tsx
+++ b/Frontend/src/pages/Jobs.tsx
@@ -332,12 +332,12 @@ const Jobs: React.FC = () => {
             </div>
 
             {/* Mobile-only Limit */}
-            <div className="flex md:hidden items-center gap-1.5 px-2">
+            <div className="flex md:hidden items-center gap-1.5">
               <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
                 onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
-                className="bg-transparent border-none text-xs font-black text-gray-600 focus:outline-none focus:ring-0 cursor-pointer pr-8"
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
               >
                 <option value={10}>10</option>
                 <option value={20}>20</option>
@@ -449,7 +449,7 @@ const Jobs: React.FC = () => {
                   </thead>
                   <tbody className="bg-white border-b border-gray-300">
                     {jobs.map((job) => {
-                      const iconData = resolveIconForJob(job.category, job.icon);
+                      const iconData = resolveIconForJob(job.professionName || job.categoryName || job.category || '', job.icon);
                       return (
                         <tr
                           key={job._id}
@@ -461,7 +461,7 @@ const Jobs: React.FC = () => {
                               <div className="h-14 w-14 flex-shrink-0 flex items-center justify-center">
                                 <img
                                   src={`${iconData.imagePath}?t=${iconTimestamp}`}
-                                  alt={job.category}
+                                  alt={job.professionName || job.categoryName || job.category || 'Category'}
                                   className="h-14 w-14 object-contain group-hover:scale-105 transition-transform"
                                   onError={(e) => {
                                     (e.target as HTMLImageElement).src = '/assets/icons/categories/professional-services.png';
@@ -478,7 +478,12 @@ const Jobs: React.FC = () => {
                                     <span className="flex-shrink-0 px-1.5 py-0.5 rounded text-[9px] font-black uppercase tracking-widest bg-red-100 text-red-700">Urgent</span>
                                   )}
                                 </div>
-                                <p className="text-[10px] text-gray-400 font-bold uppercase tracking-wider">{iconData.label || job.category}</p>
+                                <p className="text-[10px] text-gray-400 font-bold uppercase tracking-wider">
+                                  {(() => {
+                                    const lbl = iconData.label || job.professionName || job.categoryName || job.category || '';
+                                    return /^[a-fA-F0-9]{24}$/.test(lbl) ? 'General Service' : lbl;
+                                  })()}
+                                </p>
                               </div>
                             </div>
                           </td>
@@ -535,7 +540,7 @@ const Jobs: React.FC = () => {
                 {mobileViewType === 'card' ? (
                   <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4">
                     {jobs.map((job) => {
-                      const iconData = resolveIconForJob(job.category, job.icon);
+                      const iconData = resolveIconForJob(job.professionName || job.categoryName || job.category || '', job.icon);
                       return (
                         <div
                           key={job._id}
@@ -568,7 +573,7 @@ const Jobs: React.FC = () => {
                                 <div className="h-14 w-14 rounded-2xl bg-gray-50 border border-gray-100 flex items-center justify-center p-2 shadow-inner">
                                   <img 
                                     src={`${iconData.imagePath}?t=${iconTimestamp}`}
-                                    alt={job.category}
+                                    alt={job.professionName || job.categoryName || job.category || 'Category'}
                                     className="h-10 w-10 object-contain"
                                     onError={(e) => {
                                       (e.target as HTMLImageElement).src = '/assets/icons/categories/professional-services.png';
@@ -583,7 +588,10 @@ const Jobs: React.FC = () => {
                                 </h3>
                                 <div className="flex flex-wrap items-center gap-2">
                                   <span className="text-[10px] font-black text-blue-600 uppercase tracking-widest bg-blue-50 px-2 py-0.5 rounded border border-blue-100">
-                                    {iconData.label || job.category || 'General Service'}
+                                    {(() => {
+                                      const lbl = iconData.label || job.professionName || job.categoryName || job.category || '';
+                                      return /^[a-fA-F0-9]{24}$/.test(lbl) ? 'General Service' : lbl;
+                                    })()}
                                   </span>
                                   <div className="flex items-center gap-1 text-[10px] font-black text-gray-400 uppercase tracking-widest">
                                     <Users className="h-3 w-3" />
@@ -646,7 +654,7 @@ const Jobs: React.FC = () => {
                       </thead>
                       <tbody>
                         {jobs.map((job) => {
-                          const iconData = resolveIconForJob(job.category, job.icon);
+                          const iconData = resolveIconForJob(job.professionName || job.categoryName || job.category || '', job.icon);
                           return (
                             <tr 
                               key={job._id} 

--- a/Frontend/src/pages/Support.tsx
+++ b/Frontend/src/pages/Support.tsx
@@ -339,15 +339,31 @@ const Support: React.FC = () => {
         </div>
 
         <div className="px-6 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row items-center gap-4">
-          <div className="relative flex-1">
-            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
-            <input
-              type="text"
-              placeholder="Search tickets by subject, user, or ID..."
-              value={filters.searchQuery}
-              onChange={(e) => setFilters(prev => ({ ...prev, searchQuery: e.target.value }))}
-              className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm shadow-indigo-100/10"
-            />
+          <div className="flex items-center gap-2 w-full md:contents">
+            <div className="relative flex-1">
+              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <input
+                type="text"
+                placeholder="Search tickets by ID, subject or customer..."
+                value={filters.searchTerm}
+                onChange={(e) => setFilters(prev => ({ ...prev, searchTerm: e.target.value }))}
+                className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm h-10"
+              />
+            </div>
+
+            {/* Mobile-only Limit */}
+            <div className="flex md:hidden items-center gap-1.5">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+              <select 
+                value={pagination.limit}
+                onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
           </div>
 
           <div className="flex items-center gap-2 p-1 bg-white border border-gray-200 rounded-xl shadow-sm">

--- a/Frontend/src/pages/Transactions.tsx
+++ b/Frontend/src/pages/Transactions.tsx
@@ -344,12 +344,12 @@ const Transactions: React.FC = () => {
             </div>
 
             {/* Mobile-only Limit */}
-            <div className="flex md:hidden items-center gap-1.5 px-2">
-              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Limit</span>
+            <div className="flex md:hidden items-center gap-1.5">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
                 onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
-                className="bg-transparent border-none text-xs font-black text-gray-600 focus:outline-none focus:ring-0 cursor-pointer pr-8"
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
               >
                 <option value={10}>10</option>
                 <option value={20}>20</option>

--- a/Frontend/src/pages/Users.tsx
+++ b/Frontend/src/pages/Users.tsx
@@ -525,12 +525,13 @@ const Users: React.FC = () => {
               />
             </div>
 
-            <div className="flex lg:hidden items-center gap-1.5 px-2">
+            {/* Mobile-only Limit */}
+            <div className="flex lg:hidden items-center gap-1.5">
               <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
                 onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
-                className="bg-transparent text-xs font-black text-gray-600 focus:outline-none cursor-pointer"
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
               >
                 <option value={10}>10</option>
                 <option value={20}>20</option>

--- a/Frontend/src/pages/Verifications.tsx
+++ b/Frontend/src/pages/Verifications.tsx
@@ -344,15 +344,31 @@ const Verifications: React.FC = () => {
         </div>
 
         <div className="px-6 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row items-center gap-4">
-          <div className="relative flex-1">
-            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
-            <input
-              type="text"
-              placeholder="Search by name, email or KYD ID..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm"
-            />
+          <div className="flex items-center gap-2 w-full md:contents">
+            <div className="relative flex-1">
+              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
+              <input
+                type="text"
+                placeholder="Search by name, email or KYD ID..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-xl focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-sm font-medium transition-all shadow-sm"
+              />
+            </div>
+
+            {/* Mobile-only Limit */}
+            <div className="flex md:hidden items-center gap-1.5">
+              <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
+              <select 
+                value={pagination.limit}
+                onChange={(e) => setPagination(prev => ({ ...prev, limit: Number(e.target.value), page: 1 }))}
+                className="bg-white px-2 py-1 border border-gray-200 rounded-lg shadow-sm text-xs font-black text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 cursor-pointer"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+              </select>
+            </div>
           </div>
 
           <div className="flex items-center gap-2 p-1 bg-white border border-gray-200 rounded-xl shadow-sm">

--- a/Frontend/src/types/jobs.types.ts
+++ b/Frontend/src/types/jobs.types.ts
@@ -16,7 +16,11 @@ export interface Job {
   _id: string;
   title: string;
   description: string;
-  category: string;
+  category?: string;
+  categoryId?: string;
+  categoryName?: string;
+  profession?: string;
+  professionName?: string;
   icon?: string;
   media: string[];
   location?: any;

--- a/Frontend/src/utils/transactionHelpers.tsx
+++ b/Frontend/src/utils/transactionHelpers.tsx
@@ -8,7 +8,7 @@ import {
   DollarSign
 } from 'lucide-react';
 import type { Transaction } from '../types';
-import { getProfessionIconFromName } from '../constants/categoryIcons';
+import { getProfessionIconFromName, getProfessionIconByName } from '../constants/categoryIcons';
 
 /**
  * Transaction utility helper functions
@@ -18,7 +18,7 @@ import { getProfessionIconFromName } from '../constants/categoryIcons';
  * Get type color classes based on transaction type
  */
 export const getTypeColor = (type: string, transactionType: string): string => {
-  if (transactionType === 'platform_fee') {
+  if (transactionType === 'platform_fee' || transactionType === 'fee_record') {
     return 'bg-yellow-100 text-yellow-800';
   }
 
@@ -84,22 +84,28 @@ export const getTransactionStatusIcon = (status: string): JSX.Element | null => 
  */
 export const getTransactionIcon = (transaction: any): JSX.Element => {
   const { type, transactionType, jobId, job } = transaction;
+  const isFeeRecord = transactionType === 'fee_record' || transactionType === 'platform_fee' || type === 'platform_fee' || type === 'fee_payment';
   const jobInfo = jobId || job;
 
-  if (transactionType === 'platform_fee' || type === 'platform_fee') {
-    // If we have job information, try to get the profession icon
-    if (jobInfo?.category || jobInfo?.title) {
-      const iconData = getProfessionIconFromName(jobInfo.category || jobInfo.title);
-      
-      if (iconData?.imagePath) {
+  if (isFeeRecord) {
+    let iconData;
+    const professionName = jobInfo?.professionName || jobInfo?.categoryName || jobInfo?.category || jobInfo?.title;
+    
+    if (jobInfo?.icon) {
+      iconData = getProfessionIconByName(jobInfo.icon);
+    } else if (professionName) {
+      iconData = getProfessionIconFromName(professionName);
+    }
+    
+    if (iconData?.imagePath) {
         return (
-          <div className="w-8 h-8 flex items-center justify-center">
+          <div className="relative flex items-center justify-center h-full w-full p-2">
+            <div className="absolute inset-0 bg-orange-50/80 rounded-lg group-hover:bg-white transition-colors"></div>
             <img 
               src={iconData.imagePath} 
               alt={jobInfo.category || jobInfo.title} 
-              className="w-full h-full object-contain"
+              className="relative z-10 w-full h-full object-contain drop-shadow-sm"
               onError={(e) => {
-                // Fallback to DollarSign if image fails
                 const target = e.target as HTMLImageElement;
                 target.style.display = 'none';
               }}
@@ -107,7 +113,6 @@ export const getTransactionIcon = (transaction: any): JSX.Element => {
           </div>
         );
       }
-    }
     return <DollarSign className="h-5 w-5 text-yellow-600" />;
   }
 


### PR DESCRIPTION
Backend: extend transactionController job population to include categoryName, professionName and icon so frontend can display profession metadata for transactions.

Frontend: add mobile-only "Page Limit" selectors across multiple pages (Activity, ArchivedJobs, Flagged, Jobs, Support, Transactions, Users, Verifications) and standardize select styles; adjust Support and Verifications search input layout and prop usage for consistency. TopUpModal and TransactionDetailsModal no longer early-return on isOpen (only on missing transaction) and TopUpModal now renders via createPortal with adjusted z-index for proper overlay behavior.

Utils: transactionHelpers imports getProfessionIconByName and improves icon logic for fee/platform-fee records (checks professionName/categoryName/icon/title, uses image fallback and updated container styling). These changes improve transaction icon rendering and mobile pagination UX.