### PR TITLE
feat: Add image support, staged icon uploads & renames

### DIFF
--- a/Backend/app/controllers/configurationsController.js
+++ b/Backend/app/controllers/configurationsController.js
@@ -8,14 +8,22 @@ const imageKitService = require('../services/imageKitService');
 const KAYOD_PROFESSIONS_DIR = path.join(__dirname, '../../../..', 'kayod/client/src/assets/icons/professions');
 const MANAGE_PROFESSIONS_DIR = path.join(__dirname, '../../..', 'Frontend/public/assets/icons/professions');
 
+// Must stay in lockstep with the Kayod client's profession-icon resolver
+// (kayod/client: JobCard.jsx & categoryVisualMapping.js), which builds
+// professionIconsUpload/<slug>.webp from the profession NAME. If these diverge the
+// client requests a filename the stored icon doesn't have and the icon 404s.
 const generateIconFilename = (professionName) => {
+  return generateIconSlug(professionName) + '.webp';
+};
+
+const generateIconSlug = (professionName) => {
   return professionName
+    .replace(/([a-z])([A-Z])/g, '$1-$2') // camelCase → kebab (parity with Kayod client)
     .toLowerCase()
     .trim()
     .replace(/\s+/g, '-')
     .replace(/[^a-z0-9-]/g, '')
-    .replace(/-+/g, '-')
-    + '.webp';
+    .replace(/-+/g, '-');
 };
 
 // Get socket.io instance
@@ -320,13 +328,68 @@ exports.updateProfession = async (req, res) => {
       profession.quickAccessOrder = quickAccessOrder;
     }
 
+    // When a profession is renamed and its icon already lives in ImageKit (and no new
+    // icon is being uploaded in this same request), rename the ImageKit file so its name
+    // stays in sync with the profession. The Kayod client resolves profession icons by
+    // building professionIconsUpload/<slug>.webp from the profession NAME, so the stored
+    // file MUST match the new name or the icon 404s. Only the filename/URL changes — the
+    // image content is untouched — so the profession keeps using the same icon.
+    let renamedIkIcon = null;
+    let ikRollback = null;
+    const requestIconChanged = icon !== undefined && icon !== oldIcon;
+    const professionRenamed = name !== undefined && name.trim() !== oldName;
+
+    if (professionRenamed && !requestIconChanged && oldIcon && oldIcon.startsWith('ik:')) {
+      const oldFilePath = oldIcon.replace('ik:', '');
+      const normalizedPath = oldFilePath.startsWith('/') ? oldFilePath : `/${oldFilePath}`;
+      const oldFileName = normalizedPath.split('/').pop();
+      const folderPath = normalizedPath.substring(0, normalizedPath.lastIndexOf('/'));
+      // Keep the original extension (legacy ImageKit icons may be .png, new ones are .webp)
+      const oldExt = oldFileName.includes('.') ? oldFileName.slice(oldFileName.lastIndexOf('.')) : '.webp';
+      const newBaseName = generateIconSlug(name.trim());
+      const newFileName = `${newBaseName}${oldExt}`;
+
+      // Skip if the new name sanitizes to nothing (symbol-only / non-Latin), which would
+      // produce a degenerate ".webp" filename that collides across professions.
+      if (newBaseName && oldFileName !== newFileName) {
+        try {
+          await imageKitService.renameFile(normalizedPath, newFileName, true);
+          renamedIkIcon = `ik:${folderPath}/${newFileName}`;
+          profession.icon = renamedIkIcon;
+          // Compensating action: if the DB write below fails, rename the file back so the
+          // stored icon path and the actual ImageKit file never drift apart.
+          ikRollback = () => imageKitService.renameFile(`${folderPath}/${newFileName}`, oldFileName, true);
+          console.log(`[Configurations] ImageKit profession icon renamed: "${oldFileName}" → "${newFileName}"`);
+        } catch (ikErr) {
+          // e.g. a file with the new name already exists, or a transient API error.
+          // Keep the existing icon reference so the profession still shows its icon.
+          console.warn(`[Configurations] Could not rename ImageKit profession icon: ${ikErr.message}`);
+        }
+      }
+    }
+
     profession.updatedAt = new Date();
 
-    await category.save();
+    try {
+      await category.save();
+    } catch (saveErr) {
+      // The ImageKit file was already renamed but persisting the profession failed — roll
+      // the file back so the stored icon path and the actual ImageKit file stay consistent.
+      if (ikRollback) {
+        try {
+          await ikRollback();
+          console.warn('[Configurations] Rolled back ImageKit rename after profession save failure');
+        } catch (rbErr) {
+          console.error(`[Configurations] ImageKit rename rollback FAILED: ${rbErr.message}`);
+        }
+      }
+      throw saveErr;
+    }
 
     // Cascade profession name and icon changes to existing Job and Draft documents
+    const warnings = [];
     const nameChanged = name && name.trim() !== oldName;
-    const iconChanged = icon && icon !== oldIcon;
+    const iconChanged = requestIconChanged || !!renamedIkIcon;
 
     if (nameChanged || iconChanged) {
       const update = {};
@@ -334,7 +397,10 @@ exports.updateProfession = async (req, res) => {
       if (nameChanged) {
         update.professionName = name.trim();
       }
-      if (iconChanged) {
+      if (renamedIkIcon) {
+        // ImageKit file was renamed — point existing jobs/drafts at the new path.
+        update.icon = renamedIkIcon;
+      } else if (requestIconChanged) {
         if (icon.startsWith('ik:')) {
           update.icon = icon;
         } else {
@@ -343,7 +409,7 @@ exports.updateProfession = async (req, res) => {
       }
 
       // Handle icon files on disk (only for legacy custom icons)
-      if (iconChanged && !icon.startsWith('ik:') && !oldIcon?.startsWith('ik:')) {
+      if (requestIconChanged && !icon.startsWith('ik:') && !oldIcon?.startsWith('ik:')) {
         // Derive old filename from DB icon field, or fall back to generating from old profession name
         const oldFileName = oldIcon
           ? (oldIcon.startsWith('custom:') ? oldIcon.replace('custom:', '') : oldIcon)
@@ -384,6 +450,9 @@ exports.updateProfession = async (req, res) => {
         console.log(`[Configurations] Updated ${jobResult.modifiedCount} jobs.`);
       } catch (jobErr) {
         console.warn(`[Configurations] Could not update jobs: ${jobErr.message}`);
+        // Surface the partial cascade so the admin knows existing jobs may still point at
+        // the old icon path (which no longer exists after the ImageKit rename).
+        warnings.push(`Failed to update some jobs to the renamed icon: ${jobErr.message}`);
       }
 
       // Update Drafts with old profession name (no Draft model, use raw collection)
@@ -396,6 +465,7 @@ exports.updateProfession = async (req, res) => {
         console.log(`[Configurations] Updated ${draftResult.modifiedCount} drafts.`);
       } catch (draftErr) {
         console.warn(`[Configurations] Could not update drafts: ${draftErr.message}`);
+        warnings.push(`Failed to update some drafts to the renamed icon: ${draftErr.message}`);
       }
 
       console.log(
@@ -421,6 +491,7 @@ exports.updateProfession = async (req, res) => {
     res.status(200).json({
       success: true,
       profession,
+      ...(warnings.length ? { warnings } : {}),
     });
   } catch (error) {
     console.error('Error updating profession:', error);
@@ -705,9 +776,21 @@ exports.uploadCategoryIcon = async (req, res) => {
 };
 
 exports.uploadProfessionIcon = async (req, res) => {
+  // Detect client cancellation: when the browser aborts the request (user clicked
+  // "Cancel Upload"), the response socket closes before we finish writing. We upload to a
+  // TEMPORARY name first and only promote it to the live icon if the client did NOT cancel,
+  // so a cancelled upload never changes the saved icon.
+  let clientAborted = false;
+  res.on('close', () => {
+    if (!res.writableFinished) clientAborted = true;
+  });
+
+  let tempFilePath = null;
+  let tempFileId = null;
+
   try {
     console.log(`[Configurations] Starting profession icon upload for ${req.body.professionName}`);
-    
+
     if (!req.file) {
       return res.status(400).json({
         success: false,
@@ -715,7 +798,7 @@ exports.uploadProfessionIcon = async (req, res) => {
       });
     }
 
-    const { buffer, originalname } = req.file;
+    const { buffer } = req.file;
     const { professionName, oldIcon, professionId } = req.body;
 
     if (!professionName) {
@@ -725,57 +808,58 @@ exports.uploadProfessionIcon = async (req, res) => {
       });
     }
 
-    const fileExtension = path.extname(originalname).toLowerCase();
-    const sanitizedName = professionName.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-+/g, '-');
-    // Ensure we use .webp extension for consistency
+    // Use the shared slug so the uploaded filename matches what the Kayod client requests
+    const sanitizedName = generateIconSlug(professionName);
     const fileName = `${sanitizedName}.webp`;
+    // Unique, non-destructive staging name. The live icon is untouched until we commit.
+    const tempName = `tmp-${sanitizedName}-${Date.now()}-${Math.round(Math.random() * 1e6)}.webp`;
 
-    // Delete old icon from ImageKit first
-    if (oldIcon && oldIcon.startsWith('ik:')) {
-      const oldPath = oldIcon.replace('ik:', '');
-      const fileName = oldPath.split('/').pop(); // Extract filename from path
-      
+    // 1) Upload the new image to the TEMP name. This is the slow part and is safe to cancel.
+    console.log(`[Configurations] Staging profession icon on ImageKit: ${tempName}`);
+    const tempResult = await imageKitService.uploadFile(
+      buffer,
+      tempName,
+      'professionIconsUpload',
+      ['profession-icon-temp', sanitizedName]
+    );
+    tempFilePath = tempResult.filePath;
+    tempFileId = tempResult.fileId;
+
+    // 2) If the user cancelled while the upload was in flight, discard the staged file and
+    //    leave the existing icon exactly as it was.
+    if (clientAborted) {
+      await imageKitService.deleteFile(tempFileId);
+      tempFileId = null;
+      console.log(`[Configurations] Upload cancelled by client; staged file discarded, icon unchanged for "${professionName}"`);
+      return; // connection already closed — nothing to respond
+    }
+
+    // 3) Commit. Free the target filename, drop any differently-named old icon, then promote
+    //    the staged file to the live name.
+    const deleteIkByName = async (name) => {
       try {
-        console.log(`[Configurations] Deleting old ImageKit icon: ${fileName}`);
-        // Search for the specific file by name
-        const searchResult = await imageKitService.listFiles({
-          name: fileName,
-          path: 'professionIconsUpload'
-        });
+        const files = await imageKitService.listFiles({ name, path: 'professionIconsUpload' });
+        const match = files && files.find(f => f.name === name);
+        if (match) await imageKitService.deleteFile(match.fileId);
+      } catch (e) {
+        console.warn(`[Configurations] Could not delete ImageKit file ${name}: ${e.message}`);
+      }
+    };
 
-        if (searchResult && searchResult.length > 0) {
-          // Find exact match by filename
-          const exactFile = searchResult.find(file => file.name === fileName);
-          
-          if (exactFile) {
-            const deleted = await imageKitService.deleteFile(exactFile.fileId);
-            if (deleted) {
-              console.log(`[Configurations] Deleted old ImageKit icon: ${fileName} (fileId: ${exactFile.fileId})`);
-            }
-          } else {
-            console.log(`[Configurations] No exact match found for: ${fileName}`);
-          }
-        } else {
-          console.log(`[Configurations] No old ImageKit icon found: ${fileName}`);
-        }
-      } catch (deleteErr) {
-        console.warn(`[Configurations] Failed to delete old ImageKit icon ${fileName}: ${deleteErr.message}`);
+    await deleteIkByName(fileName);
+
+    if (oldIcon && oldIcon.startsWith('ik:')) {
+      const oldFileName = oldIcon.replace('ik:', '').split('/').pop();
+      if (oldFileName && oldFileName !== fileName) {
+        await deleteIkByName(oldFileName);
       }
     }
 
-    // Upload to ImageKit
-    console.log(`[Configurations] Uploading profession icon to ImageKit: ${fileName}`);
-    const ikResult = await imageKitService.uploadFile(
-      buffer,
-      fileName,
-      'professionIconsUpload',
-      ['profession-icon', sanitizedName]
-    );
+    await imageKitService.renameFile(tempFilePath, fileName, true);
+    tempFileId = null; // committed — the temp file no longer exists under its old name
+    const ikPath = `ik:/professionIconsUpload/${fileName}`;
 
-    console.log(`[Configurations] ImageKit upload successful: ${ikResult.filePath}`);
-    const ikPath = `ik:${ikResult.filePath}`;
-
-    // Update the profession in the database with the new icon
+    // 4) Update the profession in the database with the new icon
     if (professionId) {
       const category = await JobCategory.findOne({
         'professions._id': professionId,
@@ -800,7 +884,7 @@ exports.uploadProfessionIcon = async (req, res) => {
     res.status(200).json({
       success: true,
       iconName: ikPath,
-      fullPath: ikResult.url,
+      fullPath: `${process.env.IMAGEKIT_URL_ENDPOINT || 'https://ik.imagekit.io/9vpn8u272'}/professionIconsUpload/${fileName}`,
       message: 'Profession icon uploaded to ImageKit successfully',
       professionId, // Return professionId for frontend reference
     });
@@ -822,12 +906,18 @@ exports.uploadProfessionIcon = async (req, res) => {
       }
     }
   } catch (error) {
+    // Clean up the staged temp file on any failure so we never leak orphans.
+    if (tempFileId) {
+      try { await imageKitService.deleteFile(tempFileId); } catch (e) { /* best effort */ }
+    }
     console.error('Error uploading profession icon:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Failed to upload profession icon',
-      error: error.message,
-    });
+    if (!res.headersSent) {
+      res.status(500).json({
+        success: false,
+        message: 'Failed to upload profession icon',
+        error: error.message,
+      });
+    }
   }
 };
 

--- a/Backend/app/controllers/supportController.js
+++ b/Backend/app/controllers/supportController.js
@@ -1,6 +1,7 @@
 const ChatSupport = require('../models/ChatSupport');
 const User = require('../models/User');
 const mongoose = require('mongoose');
+const axios = require('axios');
 const { emitSupportUpdate, emitChatSupportUpdate, emitNewChatSupport } = require('../socket/socketHandlers');
 const { logActivity } = require('../utils/activityLogger');
 
@@ -697,33 +698,49 @@ const acceptChatSupport = async (req, res) => {
       });
     }
 
-    // Accept the ticket
-    chatSupport.assignedTo = adminObjectId;
-    chatSupport.assignedToName = req.admin?.name || req.user?.username || 'Support Agent';
-    chatSupport.acceptedBy = adminObjectId;
-    chatSupport.acceptedByName = req.admin?.name || req.user?.username || 'Support Agent';
-    chatSupport.acceptedAt = new Date();
+    // Accept the ticket — use findByIdAndUpdate to avoid re-validating the
+    // entire messages subdocument array (which may contain image-only messages
+    // or summary messages that don't satisfy strict validators on a full save).
+    const adminName = req.admin?.name || req.user?.username || 'Support Agent';
+    const now = new Date();
 
-    await chatSupport.save();
+    const freshChatSupport = await ChatSupport.findByIdAndUpdate(
+      chatSupportId,
+      {
+        $set: {
+          assignedTo:     adminObjectId,
+          assignedToName: adminName,
+          acceptedBy:     adminObjectId,
+          acceptedByName: adminName,
+          acceptedAt:     now,
+        },
+      },
+      { new: true, runValidators: false }
+    )
+      .populate('userId', 'userType profileImage')
+      .lean();
+
+    if (!freshChatSupport) {
+      return res.status(404).json({ success: false, message: 'Chat support not found after update' });
+    }
 
     console.log(`✅ Ticket ${chatSupportId} accepted by admin ${adminObjectId.toString()} (${adminUsername})`);
-    console.log(`Ticket assignedTo: ${chatSupport.assignedTo.toString()}, acceptedBy: ${chatSupport.acceptedBy.toString()}`);
 
     // Log activity - ALWAYS log this action
     try {
       await logActivity(
         adminObjectId.toString(),
         'support_accepted',
-        `Accepted support ticket: ${chatSupport.subject}`,
+        `Accepted support ticket: ${freshChatSupport.subject}`,
         {
           targetType: 'support',
           targetId: chatSupportId,
           targetModel: 'ChatSupport',
           metadata: {
-            ticketId: chatSupport.ticketId,
-            userName: chatSupport.userName,
+            ticketId: freshChatSupport.ticketId,
+            userName: freshChatSupport.userName,
             adminUsername: adminUsername,
-            subject: chatSupport.subject
+            subject: freshChatSupport.subject
           },
           ipAddress: req.ip
         }
@@ -734,12 +751,8 @@ const acceptChatSupport = async (req, res) => {
       // Continue even if activity logging fails
     }
 
-    const freshChatSupport = await ChatSupport.findById(chatSupportId)
-      .populate('userId', 'userType profileImage')
-      .lean();
-
     console.log('Emitting socket update with status:', freshChatSupport.status);
-    emitChatSupportUpdate(freshChatSupport._id, {
+    emitChatSupportUpdate(freshChatSupport, {
       status: freshChatSupport.status,
       assignedTo: freshChatSupport.assignedTo,
       assignedToName: freshChatSupport.assignedToName,
@@ -788,25 +801,7 @@ const closeChatSupport = async (req, res) => {
       ? new mongoose.Types.ObjectId(adminId)
       : null;
 
-    chatSupport.status = 'closed';
-    chatSupport.closedAt = new Date();
-
-    if (!chatSupport.assignedTo && adminObjectId) {
-      chatSupport.assignedTo = adminObjectId;
-      chatSupport.assignedToName = req.admin?.name || req.user?.username || 'Support Agent';
-    }
-
-    if (!chatSupport.statusHistory) {
-      chatSupport.statusHistory = [];
-    }
-    chatSupport.statusHistory.push({
-      status: 'resolved',
-      performedBy: adminObjectId,
-      performedByName: req.admin?.name || req.user?.username || 'Support Agent',
-      timestamp: new Date(),
-      reason: reason || 'Ticket closed'
-    });
-
+    const adminName = req.admin?.name || req.user?.username || 'Support Agent';
     const adminMsgObjectId = mongoose.Types.ObjectId.isValid(adminId)
       ? new mongoose.Types.ObjectId(adminId)
       : new mongoose.Types.ObjectId('000000000000000000000000');
@@ -815,24 +810,51 @@ const closeChatSupport = async (req, res) => {
       ? `Ticket has been resolved: ${reason}`
       : 'Ticket has been resolved';
 
-    chatSupport.messages.push({
-      senderId: adminMsgObjectId,
-      senderName: req.admin?.name || req.user?.username || 'Support Agent',
-      senderType: 'Admin',
-      message: closeMessage,
-      timestamp: new Date()
-    });
+    const newStatusEntry = {
+      status:          'resolved',
+      performedBy:     adminObjectId,
+      performedByName: adminName,
+      timestamp:       new Date(),
+      reason:          reason || 'Ticket closed'
+    };
 
-    await chatSupport.save();
-    console.log(`✅ Ticket ${chatSupportId} closed - status: ${chatSupport.status}`);
+    const newCloseMsg = {
+      senderId:   adminMsgObjectId,
+      senderName: adminName,
+      senderType: 'Admin',
+      message:    closeMessage,
+      timestamp:  new Date()
+    };
+
+    // Use findByIdAndUpdate + $push / $set so we never re-validate the entire
+    // messages subdocument array (which may contain image-only messages).
+    const setFields = {
+      status:   'closed',
+      closedAt: new Date(),
+      lastMessage: { text: closeMessage, timestamp: newCloseMsg.timestamp }
+    };
+    if (!chatSupport.assignedTo && adminObjectId) {
+      setFields.assignedTo     = adminObjectId;
+      setFields.assignedToName = adminName;
+    }
+
+    await ChatSupport.findByIdAndUpdate(
+      chatSupportId,
+      {
+        $set:  setFields,
+        $push: {
+          statusHistory: newStatusEntry,
+          messages:      newCloseMsg,
+        },
+      },
+      { runValidators: false }
+    );
+
+    console.log(`✅ Ticket ${chatSupportId} closed`);
 
     if (adminObjectId) {
       try {
-        await User.findByIdAndUpdate(
-          adminObjectId,
-          { $inc: { ticketsResolved: 1 } },
-          { new: true }
-        );
+        await User.findByIdAndUpdate(adminObjectId, { $inc: { ticketsResolved: 1 } }, { new: true });
         console.log(`✅ Incremented ticketsResolved for admin ${adminObjectId}`);
       } catch (updateError) {
         console.error('❌ Error updating admin ticketsResolved:', updateError);
@@ -841,11 +863,7 @@ const closeChatSupport = async (req, res) => {
 
     if (chatSupport.userId) {
       try {
-        await User.findByIdAndUpdate(
-          chatSupport.userId,
-          { $inc: { ticketsSubmittedResolved: 1 } },
-          { new: true }
-        );
+        await User.findByIdAndUpdate(chatSupport.userId, { $inc: { ticketsSubmittedResolved: 1 } }, { new: true });
         console.log(`✅ Incremented ticketsSubmittedResolved for user ${chatSupport.userId}`);
       } catch (updateError) {
         console.error('❌ Error updating user ticketsSubmittedResolved:', updateError);
@@ -875,13 +893,45 @@ const closeChatSupport = async (req, res) => {
       .lean();
 
     console.log('Emitting socket update with status:', freshChatSupport.status);
-    emitChatSupportUpdate(freshChatSupport._id, {
+    emitChatSupportUpdate(freshChatSupport, {
       status: freshChatSupport.status,
       closedAt: freshChatSupport.closedAt,
       updatedAt: freshChatSupport.updatedAt,
       messages: freshChatSupport.messages,
       statusHistory: freshChatSupport.statusHistory
     });
+
+    // Notify the Kayod mobile server to push the close message to mobile clients
+    // The change stream on the Kayod server may or may not fire reliably, so we
+    // directly call its broadcast endpoint to guarantee delivery.
+    try {
+      const kayodUrl = process.env.KAYOD_BACKEND_URL || 'http://localhost:8080';
+      const kayodApiKey = process.env.KAYOD_API_KEY || 'kayod-admin-access-key-123';
+      const closeMsg = freshChatSupport.messages[freshChatSupport.messages.length - 1];
+      if (closeMsg) {
+        await axios.post(
+          `${kayodUrl}/api/support/broadcast-message`,
+          {
+            chatSupportId,
+            message: {
+              _id:        closeMsg._id.toString(),
+              senderId:   closeMsg.senderId.toString(),
+              senderName: closeMsg.senderName,
+              senderType: closeMsg.senderType,
+              message:    closeMsg.message,
+              timestamp:  closeMsg.timestamp instanceof Date
+                ? closeMsg.timestamp.toISOString()
+                : closeMsg.timestamp,
+            }
+          },
+          { headers: { 'x-api-key': kayodApiKey } }
+        );
+        console.log('✅ Notified Kayod server to broadcast close message to mobile');
+      }
+    } catch (notifyError) {
+      // Non-critical — mobile will still receive via change stream
+      console.warn('⚠️ Failed to notify Kayod server (non-critical):', notifyError.message);
+    }
 
     res.json({ success: true, chatSupport: freshChatSupport });
   } catch (error) {
@@ -968,13 +1018,42 @@ const reopenChatSupport = async (req, res) => {
       .lean();
 
     console.log('Emitting socket update with status:', freshChatSupport.status);
-    emitChatSupportUpdate(freshChatSupport._id, {
+    emitChatSupportUpdate(freshChatSupport, {
       status: freshChatSupport.status,
       closedAt: freshChatSupport.closedAt,
       updatedAt: freshChatSupport.updatedAt,
       messages: freshChatSupport.messages,
       statusHistory: freshChatSupport.statusHistory
     });
+
+    // Notify Kayod mobile server to push the reopen message to mobile clients
+    try {
+      const kayodUrl = process.env.KAYOD_BACKEND_URL || 'http://localhost:8080';
+      const kayodApiKey = process.env.KAYOD_API_KEY || 'kayod-admin-access-key-123';
+      const reopenMsg = freshChatSupport.messages[freshChatSupport.messages.length - 1];
+      if (reopenMsg) {
+        await axios.post(
+          `${kayodUrl}/api/support/broadcast-message`,
+          {
+            chatSupportId,
+            message: {
+              _id:        reopenMsg._id.toString(),
+              senderId:   reopenMsg.senderId.toString(),
+              senderName: reopenMsg.senderName,
+              senderType: reopenMsg.senderType,
+              message:    reopenMsg.message,
+              timestamp:  reopenMsg.timestamp instanceof Date
+                ? reopenMsg.timestamp.toISOString()
+                : reopenMsg.timestamp,
+            }
+          },
+          { headers: { 'x-api-key': kayodApiKey } }
+        );
+        console.log('✅ Notified Kayod server to broadcast reopen message to mobile');
+      }
+    } catch (notifyError) {
+      console.warn('⚠️ Failed to notify Kayod server (non-critical):', notifyError.message);
+    }
 
     res.json({ success: true, chatSupport: freshChatSupport });
   } catch (error) {
@@ -1033,6 +1112,32 @@ const addChatSupportMessage = async (req, res) => {
     await chatSupport.save();
 
     const savedMessage = chatSupport.messages[chatSupport.messages.length - 1];
+
+    // Notify Kayod mobile server to push admin message to mobile clients
+    try {
+      const kayodUrl = process.env.KAYOD_BACKEND_URL || 'http://localhost:8080';
+      const kayodApiKey = process.env.KAYOD_API_KEY || 'kayod-admin-access-key-123';
+      await axios.post(
+        `${kayodUrl}/api/support/broadcast-message`,
+        {
+          chatSupportId,
+          message: {
+            _id:        savedMessage._id.toString(),
+            senderId:   savedMessage.senderId.toString(),
+            senderName: savedMessage.senderName,
+            senderType: savedMessage.senderType,
+            message:    savedMessage.message,
+            timestamp:  savedMessage.timestamp instanceof Date
+              ? savedMessage.timestamp.toISOString()
+              : savedMessage.timestamp,
+          }
+        },
+        { headers: { 'x-api-key': kayodApiKey } }
+      );
+      console.log('✅ Notified Kayod server to broadcast admin message to mobile');
+    } catch (notifyError) {
+      console.warn('⚠️ Failed to notify Kayod server (non-critical):', notifyError.message);
+    }
 
     res.json({ success: true, message: savedMessage, chatSupport });
   } catch (error) {

--- a/Backend/app/models/ChatSupport.js
+++ b/Backend/app/models/ChatSupport.js
@@ -133,8 +133,13 @@ const chatSupportSchema = new mongoose.Schema({
     },
     message: {
       type: String,
-      required: true,
+      required: false,  // image-only messages have message: '' — must not fail required check
+      default: '',
       trim: true
+    },
+    imageUrl: {
+      type: String,
+      default: null
     },
     timestamp: {
       type: Date,

--- a/Backend/app/routes/support.js
+++ b/Backend/app/routes/support.js
@@ -26,11 +26,31 @@ router.get('/chat/:chatSupportId', getChatSupport);
 router.post('/chat/:chatSupportId/messages', addChatSupportMessage);
 
 // Notification endpoints (no auth required for inter-service communication)
-router.post('/notify-new-ticket', (req, res) => {
+router.post('/notify-new-ticket', async (req, res) => {
   console.log('New support ticket notification received:', req.body);
-  const { emitSupportUpdate } = require('../socket/socketHandlers');
-  emitSupportUpdate({ ticketId: req.body.ticketId }, 'new_ticket');
-  res.json({ success: true });
+  const { emitSupportUpdate, emitNewChatSupport } = require('../socket/socketHandlers');
+  const ChatSupport = require('../models/ChatSupport');
+
+  try {
+    // If a ChatSupport was created alongside the ticket, emit it to the admin panel
+    const { chatSupportId } = req.body;
+    if (chatSupportId) {
+      const chatSupport = await ChatSupport.findById(chatSupportId).lean();
+      if (chatSupport) {
+        // Emit support:new_chat — this triggers fetchTickets() in useSupportSocket
+        emitNewChatSupport(chatSupport);
+        console.log('✅ Emitted support:new_chat for chatSupportId:', chatSupportId);
+      }
+    }
+
+    // Also emit the legacy ticket_updated event for backwards compat
+    emitSupportUpdate({ ticketId: req.body.ticketId }, 'new_ticket');
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Error handling notify-new-ticket:', err);
+    // Still return 200 so the mobile side doesn't retry indefinitely
+    res.json({ success: false, message: err.message });
+  }
 });
 
 // Upsert metadata/snapshot and emit new message

--- a/Backend/app/services/imageKitService.js
+++ b/Backend/app/services/imageKitService.js
@@ -86,6 +86,26 @@ const imageKitService = {
 			return false;
 		}
 	},
+
+	/**
+	 * Rename a file in place (keeps it in the same folder, same image content)
+	 * @param {string} filePath - full current path, e.g. /professionIconsUpload/plumber.webp
+	 * @param {string} newFileName - new filename only (no path), e.g. pipe-fitter.webp
+	 * @param {boolean} purgeCache - purge the CDN cache for the old URL
+	 */
+	renameFile: async (filePath, newFileName, purgeCache = true) => {
+		try {
+			const result = await imagekit.renameFile({
+				filePath,
+				newFileName,
+				purgeCache,
+			});
+			return result;
+		} catch (error) {
+			console.error("[ImageKit Backend] renameFile failed:", error);
+			throw error;
+		}
+	},
 };
 
 module.exports = imageKitService;

--- a/Backend/app/socket/socketHandlers.js
+++ b/Backend/app/socket/socketHandlers.js
@@ -110,6 +110,7 @@ const setupSocketHandlers = (io) => {
               senderName: savedMessage.senderName,
               senderType: savedMessage.senderType,
               message: savedMessage.message,
+              imageUrl: savedMessage.imageUrl || null,
               timestamp: savedMessage.timestamp.toISOString()
             }
           };
@@ -223,6 +224,7 @@ const setupMainNamespaceHandlers = (io) => {
             senderName: savedMessage.senderName,
             senderType: savedMessage.senderType,
             message: savedMessage.message,
+            imageUrl: savedMessage.imageUrl || null,
             timestamp: savedMessage.timestamp.toISOString()
           }
         };
@@ -651,28 +653,45 @@ const setupChatSupportChangeStream = () => {
               Object.keys(change.updateDescription?.updatedFields || {}).some(key => key.startsWith('messages.'));
 
             if (hasNewMessage && chatSupport.messages.length > 0) {
-              const lastMessage = chatSupport.messages[chatSupport.messages.length - 1];
+              // Determine which messages are newly added.
+              // When multiple messages are pushed in a single save() (e.g. ticket creation
+              // with 2 image attachments), MongoDB reports each as a separate updatedField
+              // key like "messages.N", "messages.N+1", etc. We must emit ALL of them —
+              // not just the last one — so the admin panel shows every new message.
+              const updatedFields = change.updateDescription?.updatedFields || {};
+              const individualKeys = Object.keys(updatedFields).filter(k => /^messages\.\d+$/.test(k));
 
-              const messageData = {
-                chatSupportId,
-                message: {
-                  _id: lastMessage._id.toString(),
-                  senderId: lastMessage.senderId.toString(),
-                  senderName: lastMessage.senderName,
-                  senderType: lastMessage.senderType,
-                  message: lastMessage.message,
-                  timestamp: lastMessage.timestamp.toISOString()
-                }
-              };
-
-
-              if (adminNamespace) {
-                adminNamespace.to(`support:${chatSupportId}`).emit('support:new_message', messageData);
-                adminNamespace.to('admin').emit('support:new_message', messageData);
+              let msgsToEmit = [];
+              if (individualKeys.length > 0) {
+                // Specific indices were set — collect them in ascending order
+                const indices = individualKeys
+                  .map(k => parseInt(k.split('.')[1], 10))
+                  .sort((a, b) => a - b);
+                msgsToEmit = indices.map(i => chatSupport.messages[i]).filter(Boolean);
+              } else {
+                // Whole array replaced (e.g. insert) — just emit the last message
+                msgsToEmit = [chatSupport.messages[chatSupport.messages.length - 1]];
               }
 
-              // Note: Mobile clients receive notifications via their global socket connection
-              // No HTTP broadcast needed - the mobile app SocketContext handles this
+              if (adminNamespace) {
+                for (const msg of msgsToEmit) {
+                  const messageData = {
+                    chatSupportId,
+                    message: {
+                      _id: msg._id.toString(),
+                      senderId: msg.senderId.toString(),
+                      senderName: msg.senderName,
+                      senderType: msg.senderType,
+                      message: msg.message,
+                      imageUrl: msg.imageUrl || null,
+                      timestamp: msg.timestamp.toISOString()
+                    }
+                  };
+                  adminNamespace.to(`support:${chatSupportId}`).emit('support:new_message', messageData);
+                  adminNamespace.to('admin').emit('support:new_message', messageData);
+                }
+              }
+              // Note: Mobile clients receive notifications via their own socket connection
             }
 
             if (change.updateDescription?.updatedFields?.status) {

--- a/Frontend/src/components/Modals/SupportChatModal.tsx
+++ b/Frontend/src/components/Modals/SupportChatModal.tsx
@@ -27,6 +27,7 @@ interface Message {
   senderId?: string;
   senderName?: string;
   message: string;
+  imageUrl?: string;
   timestamp: string;
 }
 
@@ -496,9 +497,11 @@ const SupportChatModal: React.FC<SupportChatModalProps> = ({
 
                 // Check if this is a system message
                 const isTicketSummary =
-                  msg.message.includes("PREVIOUS TICKET RESOLVED") ||
-                  msg.message.includes("Previous Ticket Summary");
-                const messageText = msg.message.toLowerCase();
+                  !!msg.message && (
+                    msg.message.includes("PREVIOUS TICKET RESOLVED") ||
+                    msg.message.includes("Previous Ticket Summary")
+                  );
+                const messageText = (msg.message || '').toLowerCase();
                 const isSystemMessage =
                   !isTicketSummary &&
                   isAdmin &&
@@ -602,63 +605,127 @@ const SupportChatModal: React.FC<SupportChatModalProps> = ({
 
                   return (
                     <React.Fragment key={msg._id || index}>
-                      <div className="flex items-center justify-center my-6">
-                        <div className="max-w-2xl w-full space-y-4">
+                      <div className="flex justify-center my-8 px-4">
+                        <div className="w-full max-w-xs">
+
                           {sections.map((section, sectionIndex) => {
                             const isResolved = section.title.includes("✓");
                             const isNewTicket = section.title.includes("⚡");
+                            const titleText = section.title.replace(
+                              /^[✓⚡📋]\s*/,
+                              "",
+                            );
 
                             return (
-                              <div
-                                key={sectionIndex}
-                                className={`rounded-lg border-2 p-5 ${
-                                  isResolved
-                                    ? "bg-green-50 border-green-300"
-                                    : isNewTicket
-                                      ? "bg-blue-50 border-blue-300"
-                                      : "bg-gray-50 border-gray-300"
-                                }`}
-                              >
-                                <div className="mb-4">
-                                  <h3 className="text-sm font-bold text-gray-900 uppercase tracking-wide">
-                                    {section.title.replace(/^[✓⚡📋]\s*/, "")}
-                                  </h3>
-                                </div>
-
-                                {Object.keys(section.details).length > 0 && (
-                                  <div className="space-y-2.5">
-                                    {Object.entries(section.details).map(
-                                      ([key, value], detailIndex) => (
-                                        <div
-                                          key={detailIndex}
-                                          className="flex justify-between items-start"
-                                        >
-                                          <span className="text-xs font-medium text-gray-600 uppercase tracking-wide">
-                                            {key}
-                                          </span>
-                                          <span className="text-sm font-semibold text-gray-900 text-right max-w-xs">
-                                            {value}
-                                          </span>
-                                        </div>
-                                      ),
-                                    )}
+                              <React.Fragment key={sectionIndex}>
+                                {/* Dashed connector between cards */}
+                                {sectionIndex > 0 && (
+                                  <div className="flex justify-center py-0.5">
+                                    <div className="w-px h-5 border-l-2 border-dashed border-gray-300" />
                                   </div>
                                 )}
-                              </div>
+
+                                <div
+                                  className={`rounded-2xl overflow-hidden ${
+                                    isResolved
+                                      ? "ring-1 ring-emerald-200"
+                                      : isNewTicket
+                                        ? "ring-1 ring-orange-200"
+                                        : "ring-1 ring-gray-200"
+                                  }`}
+                                >
+                                  {/* Coloured header bar */}
+                                  <div
+                                    className={`flex items-center justify-between px-4 py-2.5 ${
+                                      isResolved
+                                        ? "bg-emerald-500"
+                                        : isNewTicket
+                                          ? "bg-orange-400"
+                                          : "bg-gray-500"
+                                    }`}
+                                  >
+                                    <div className="flex items-center gap-2">
+                                      {isResolved && (
+                                        <CheckCircle
+                                          className="w-3.5 h-3.5 text-white"
+                                          strokeWidth={2.5}
+                                        />
+                                      )}
+                                      {isNewTicket && (
+                                        <MessageSquare
+                                          className="w-3.5 h-3.5 text-white"
+                                          strokeWidth={2.5}
+                                        />
+                                      )}
+                                      <span className="text-white text-[11px] font-bold uppercase tracking-widest">
+                                        {titleText}
+                                      </span>
+                                    </div>
+                                    {isResolved && (
+                                      <span className="text-[9px] font-bold uppercase tracking-wider bg-white/25 text-white rounded-full px-2 py-0.5">
+                                        Closed
+                                      </span>
+                                    )}
+                                    {isNewTicket && (
+                                      <span className="text-[9px] font-bold uppercase tracking-wider bg-white/25 text-white rounded-full px-2 py-0.5">
+                                        Open
+                                      </span>
+                                    )}
+                                  </div>
+
+                                  {/* Detail rows */}
+                                  {Object.keys(section.details).length > 0 && (
+                                    <div
+                                      className={`divide-y bg-white ${
+                                        isResolved
+                                          ? "divide-emerald-50"
+                                          : isNewTicket
+                                            ? "divide-orange-50"
+                                            : "divide-gray-50"
+                                      }`}
+                                    >
+                                      {Object.entries(section.details).map(
+                                        ([key, value], detailIndex) => (
+                                          <div
+                                            key={detailIndex}
+                                            className="flex items-start justify-between gap-4 px-4 py-2.5"
+                                          >
+                                            <span
+                                              className={`text-[10px] font-semibold uppercase tracking-wide whitespace-nowrap flex-shrink-0 ${
+                                                isResolved
+                                                  ? "text-emerald-600"
+                                                  : isNewTicket
+                                                    ? "text-orange-500"
+                                                    : "text-gray-500"
+                                              }`}
+                                            >
+                                              {key}
+                                            </span>
+                                            <span className="text-[12px] text-gray-800 font-medium text-right leading-snug">
+                                              {value}
+                                            </span>
+                                          </div>
+                                        ),
+                                      )}
+                                    </div>
+                                  )}
+                                </div>
+                              </React.Fragment>
                             );
                           })}
 
-                          <div className="text-center">
-                            <p className="text-xs text-gray-500">
+                          {/* Timestamp pill */}
+                          <div className="flex justify-center mt-4">
+                            <span className="inline-flex items-center gap-1.5 text-[10px] text-gray-400 bg-gray-100 rounded-full px-3 py-1">
+                              <Calendar className="w-2.5 h-2.5" />
                               {new Date(msg.timestamp).toLocaleDateString(
                                 "en-US",
                                 {
-                                  month: "long",
+                                  month: "short",
                                   day: "numeric",
                                   year: "numeric",
                                 },
-                              )}{" "}
-                              at{" "}
+                              )}{" · "}
                               {new Date(msg.timestamp).toLocaleTimeString(
                                 "en-US",
                                 {
@@ -667,8 +734,9 @@ const SupportChatModal: React.FC<SupportChatModalProps> = ({
                                   hour12: true,
                                 },
                               )}
-                            </p>
+                            </span>
                           </div>
+
                         </div>
                       </div>
                     </React.Fragment>
@@ -808,17 +876,33 @@ const SupportChatModal: React.FC<SupportChatModalProps> = ({
                           ref={(el) => {
                             messageRefs.current[messageId] = el;
                           }}
-                          className={`inline-block px-4 py-2.5 rounded-2xl ${
+                          className={`inline-block rounded-2xl overflow-hidden ${
                             isAdmin
                               ? "bg-blue-600 text-white"
                               : "bg-white text-gray-900 shadow-sm"
-                          }`}
+                          } ${msg.imageUrl && !msg.message ? "" : "px-4 py-2.5"}`}
                         >
+                          {msg.imageUrl && (
+                            <a
+                              href={msg.imageUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              title="Click to open full image"
+                            >
+                              <img
+                                src={msg.imageUrl}
+                                alt="Attachment"
+                                className="block max-w-[240px] max-h-[240px] w-auto h-auto object-cover rounded-2xl cursor-pointer hover:opacity-90 transition-opacity"
+                                style={{ display: 'block' }}
+                              />
+                            </a>
+                          )}
                           {(() => {
+                            if (!msg.message) return null;
                             const parsed = parseMessageContent(msg.message);
                             const isUser = !isAdmin;
                             return (
-                              <>
+                              <div className={msg.imageUrl ? "px-4 pb-2.5 pt-1" : ""}>
                                 {parsed.body && (
                                   <p className="text-sm leading-relaxed">
                                     {parsed.body}
@@ -832,7 +916,7 @@ const SupportChatModal: React.FC<SupportChatModalProps> = ({
                                     {msg.message}
                                   </p>
                                 )}
-                              </>
+                              </div>
                             );
                           })()}
                         </div>

--- a/Frontend/src/components/Settings/AddProfessionModal.tsx
+++ b/Frontend/src/components/Settings/AddProfessionModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 import { Upload, Image as ImageIcon } from 'lucide-react';
 import SideModal from '../SideModal';
 import { settingsService } from '../../services';
+import { generateProfessionIconFilename } from '../../constants/categoryIcons';
 
 interface AddProfessionModalProps {
   isOpen: boolean;
@@ -140,7 +141,7 @@ const AddProfessionModal: React.FC<AddProfessionModalProps> = ({
               )}
             </div>
             <p className="text-xs text-gray-500 mt-1">
-              PNG or JPG, max 5MB. Icon will be saved as: {professionName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '') || 'profession-name'}.png
+              PNG or JPG, max 5MB. Uploaded to ImageKit as: {professionName.trim() ? generateProfessionIconFilename(professionName) : 'profession-name.webp'}
             </p>
           </div>
         </div>

--- a/Frontend/src/components/Settings/EditCategoryDrawer.tsx
+++ b/Frontend/src/components/Settings/EditCategoryDrawer.tsx
@@ -64,12 +64,24 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const professionFileInputRef = React.useRef<HTMLInputElement>(null);
+  const uploadAbortRef = React.useRef<AbortController | null>(null);
   const [currentProfessionForUpload, setCurrentProfessionForUpload] = useState<string | null>(null);
   const [showTransferModal, setShowTransferModal] = useState(false);
   const [transferProfession, setTransferProfession] = useState<Profession | null>(null);
   const [isDraggingIcon, setIsDraggingIcon] = useState(false);
+  // Staged-but-not-yet-uploaded icon. The file only hits ImageKit when the user clicks
+  // Save Changes, so cancelling/closing the editor never changes the saved icon.
+  const [pendingIconFile, setPendingIconFile] = useState<File | null>(null);
+  const [pendingIconPreview, setPendingIconPreview] = useState<string | null>(null);
   const { socket } = useSocket();
   const queryClient = useQueryClient();
+
+  // Revoke the previous local preview object URL when it changes or on unmount.
+  React.useEffect(() => {
+    return () => {
+      if (pendingIconPreview) URL.revokeObjectURL(pendingIconPreview);
+    };
+  }, [pendingIconPreview]);
 
   // Filter professions based on search query
   const filteredProfessions = professions.filter(profession =>
@@ -91,6 +103,8 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
       setIsAddingProfession(false);
       setIsEditingProfession(false);
       setProfessionSearchQuery('');
+      setPendingIconFile(null);
+      setPendingIconPreview(null);
     }
   }, [isOpen, initialProfession]);
 
@@ -133,7 +147,20 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
     };
   }, [socket, editingProfession]);
 
+  const resetProfessionEditState = () => {
+    setEditingProfession(null);
+    setEditingProfessionName('');
+    setEditingProfessionIcon(undefined);
+    setIsAddingProfession(false);
+    setIsEditingProfession(false);
+    setNewProfessionName('');
+    setPendingIconFile(null);
+    setPendingIconPreview(null);
+  };
+
   const handleEditProfession = (profession: Profession) => {
+    setPendingIconFile(null);
+    setPendingIconPreview(null);
     setEditingProfession(profession);
     setEditingProfessionName(profession.name);
     setEditingProfessionIcon(profession.icon);
@@ -142,87 +169,78 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
   };
 
   const handleSaveProfessionEdit = async () => {
-    if (!editingProfessionName.trim()) {
+    const finalName = editingProfessionName.trim();
+    if (!finalName) {
       toast.error('Profession name cannot be empty');
       return;
     }
 
     try {
-      if (editingProfession) {
-        // Update existing profession
-        const updateData: any = {};
-        const nameChanged = editingProfessionName.trim() !== editingProfession.name;
-        
-        if (nameChanged) {
-          updateData.name = editingProfessionName.trim();
-          
-          // Automatically update icon filename when profession name changes
-          // Only if the current icon follows the naming pattern or if there's no custom icon
-          const currentIcon = editingProfessionIcon || editingProfession.icon;
-          const shouldUpdateIcon = !currentIcon || 
-            currentIcon.includes(editingProfession.name.toLowerCase().replace(/\s+/g, '-'));
-          
-          if (shouldUpdateIcon) {
-            const newIconFilename = generateIconFilename(editingProfessionName.trim());
-            updateData.icon = newIconFilename;
-            setEditingProfessionIcon(newIconFilename);
-            
-            toast.success(`Icon filename will be updated to: ${newIconFilename}`);
-          }
-        }
-        
-        if (editingProfessionIcon !== editingProfession.icon && !nameChanged) {
-          updateData.icon = editingProfessionIcon;
-        }
-
-        if (Object.keys(updateData).length > 0) {
-          await settingsService.updateProfession(editingProfession._id, updateData);
-          
-          setProfessions(prev =>
-            prev.map(prof =>
-              prof._id === editingProfession._id
-                ? { ...prof, ...updateData }
-                : prof
-            )
-          );
-          
-          const message = nameChanged && updateData.icon 
-            ? 'Profession name and icon updated successfully'
-            : nameChanged 
-            ? 'Profession name updated successfully'
-            : 'Profession icon updated successfully';
-          
-          toast.success(message);
-        }
-      } else {
-        // Add new profession
+      // Add new profession (the add form does not offer an icon dropzone)
+      if (!editingProfession) {
         const response = await settingsService.createProfession({
-          name: editingProfessionName.trim(),
+          name: finalName,
           categoryId: category._id,
         });
-        
         setProfessions(prev => [...prev, response.profession]);
         toast.success('Profession added successfully');
+        resetProfessionEditState();
+        return;
       }
-      
-      // Reset editing state
-      setEditingProfession(null);
-      setEditingProfessionName('');
-      setEditingProfessionIcon(undefined);
-      setIsAddingProfession(false);
-      setIsEditingProfession(false);
-      setNewProfessionName('');
+
+      const nameChanged = finalName !== editingProfession.name;
+      let committedIcon: string | undefined;
+
+      // 1) Upload the staged icon FIRST, under the final name. This is the ONLY place the
+      //    icon reaches ImageKit, so cancelling before Save leaves the saved icon untouched.
+      if (pendingIconFile) {
+        const uploaded = await uploadStagedIcon(
+          pendingIconFile,
+          finalName,
+          editingProfession.icon,
+          editingProfession._id,
+        );
+        if (uploaded === null) return; // upload was cancelled — keep the editor open
+        committedIcon = uploaded;
+      }
+
+      // 2) Persist the name change. When an icon was just uploaded we pass it along so the
+      //    backend does not try to rename a file that already sits at the final name.
+      const updateData: { name?: string; icon?: string } = {};
+      if (nameChanged) updateData.name = finalName;
+      if (nameChanged && committedIcon) updateData.icon = committedIcon;
+
+      if (Object.keys(updateData).length > 0) {
+        const res = await settingsService.updateProfession(editingProfession._id, updateData);
+        const resolvedIcon = res?.profession?.icon ?? committedIcon;
+        setProfessions(prev =>
+          prev.map(prof =>
+            prof._id === editingProfession._id
+              ? { ...prof, name: finalName, ...(resolvedIcon ? { icon: resolvedIcon } : {}) }
+              : prof
+          )
+        );
+        setProfessionIconTimestamps(prev => ({ ...prev, [editingProfession._id]: Date.now() }));
+        queryClient.invalidateQueries({ queryKey: ['job-categories'] });
+      }
+
+      if (nameChanged || committedIcon) {
+        toast.success(
+          nameChanged && committedIcon
+            ? 'Profession name and icon updated successfully'
+            : nameChanged
+              ? 'Profession name updated successfully'
+              : 'Profession icon updated successfully'
+        );
+      }
+      resetProfessionEditState();
     } catch (error: any) {
       toast.error(error.response?.data?.message || 'Failed to save profession');
     }
   };
 
   const handleCancelProfessionEdit = () => {
-    setEditingProfession(null);
-    setEditingProfessionName('');
-    setEditingProfessionIcon(undefined);
-    setIsAddingProfession(false);
-    setIsEditingProfession(false);
+    resetProfessionEditState();
   };
 
   const handleDeleteProfession = async (professionId: string) => {
@@ -306,35 +324,47 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
     }
   };
 
-  // Shared function to process an image file for profession icon upload
-  const processUploadFile = useCallback(async (file: File, professionId: string) => {
+  // Stage a chosen image LOCALLY. It is not uploaded until the user clicks Save Changes,
+  // so cancelling or closing the editor never touches ImageKit or the saved icon.
+  const stageProfessionIcon = useCallback((file: File) => {
     if (!file.type.startsWith('image/')) {
       toast.error('Please upload an image file');
       return;
     }
-
     if (file.size > 5 * 1024 * 1024) {
       toast.error('File size must be less than 5MB');
       return;
     }
+    setPendingIconFile(file);
+    setPendingIconPreview(URL.createObjectURL(file));
+  }, []);
 
-    const profession = professions.find(p => p._id === professionId);
-    if (!profession) return;
+  // Upload the staged icon to ImageKit. Called only from Save. Returns the new icon path,
+  // or null if the user cancelled the in-flight upload.
+  const uploadStagedIcon = useCallback(async (
+    file: File,
+    professionName: string,
+    oldIcon: string | undefined,
+    professionId: string,
+  ): Promise<string | null> => {
+    const controller = new AbortController();
+    uploadAbortRef.current = controller;
 
     try {
       setUploadingProfessionIcon(professionId);
       const response = await settingsService.uploadProfessionIcon(
         file,
-        profession.name,
-        profession.icon,
-        professionId
+        professionName,
+        oldIcon,
+        professionId,
+        controller.signal
       );
-      
+
       if (editingProfession && editingProfession._id === professionId) {
         setEditingProfessionIcon(response.iconName);
         setEditingProfession(prev => prev ? { ...prev, icon: response.iconName } : null);
       }
-      
+
       setProfessions(prev =>
         prev.map(prof =>
           prof._id === professionId
@@ -342,34 +372,44 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
             : prof
         )
       );
-      
+
       setProfessionIconTimestamps(prev => ({
         ...prev,
         [professionId]: Date.now()
       }));
-      
+
       setIconTimestamp(Date.now());
 
-      // Invalidate job-categories cache to refresh parent component
-      queryClient.invalidateQueries({ queryKey: ['job-categories'] });
-
-      toast.success('Profession icon uploaded successfully');
+      return response.iconName as string;
     } catch (error: any) {
-      toast.error(error.response?.data?.message || 'Failed to upload profession icon');
+      // Axios flags user-cancelled requests with code ERR_CANCELED / name CanceledError.
+      if (error?.code === 'ERR_CANCELED' || error?.name === 'CanceledError') {
+        toast('Upload cancelled');
+        return null;
+      }
+      throw error;
     } finally {
+      uploadAbortRef.current = null;
       setUploadingProfessionIcon(null);
       setCurrentProfessionForUpload(null);
       if (professionFileInputRef.current) {
         professionFileInputRef.current.value = '';
       }
     }
-  }, [professions, editingProfession]);
+  }, [editingProfession, queryClient]);
 
-  const handleProfessionFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleProfessionFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (!file || !currentProfessionForUpload) return;
-    await processUploadFile(file, currentProfessionForUpload);
+    if (file) stageProfessionIcon(file);
+    if (professionFileInputRef.current) {
+      professionFileInputRef.current.value = '';
+    }
   };
+
+  // Abort an in-flight profession icon upload.
+  const cancelProfessionIconUpload = useCallback(() => {
+    uploadAbortRef.current?.abort();
+  }, []);
 
   const triggerProfessionIconUpload = () => {
     if (editingProfession) {
@@ -391,7 +431,7 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
     setIsDraggingIcon(false);
   }, []);
 
-  const handleIconDrop = useCallback(async (e: React.DragEvent) => {
+  const handleIconDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
     setIsDraggingIcon(false);
@@ -401,9 +441,8 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
     const files = e.dataTransfer.files;
     if (files.length === 0) return;
 
-    const file = files[0];
-    await processUploadFile(file, editingProfession._id);
-  }, [editingProfession, processUploadFile]);
+    stageProfessionIcon(files[0]);
+  }, [editingProfession, stageProfessionIcon]);
 
   const getProfessionIconName = (profession: Profession) => {
     if (editingProfession && editingProfession._id === profession._id && editingProfessionIcon !== undefined) {
@@ -810,11 +849,11 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
                         backgroundColor: `${getProfessionIconData(editingProfession).color}15` 
                       }}
                     >
-                      <img 
-                        key={getProfessionIconData(editingProfession).imagePath}
-                        src={getProfessionIconData(editingProfession).imagePath}
+                      <img
+                        key={pendingIconPreview || getProfessionIconData(editingProfession).imagePath}
+                        src={pendingIconPreview || getProfessionIconData(editingProfession).imagePath}
                         alt="Icon"
-                        className="w-10 h-10 object-contain" 
+                        className="w-10 h-10 object-contain"
                         onError={(e) => {
                           const target = e.target as HTMLImageElement;
                           target.src = `/src/assets/icons/Default_Icon.webp?t=${Date.now()}`;
@@ -830,6 +869,11 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
                       <div className="flex flex-col items-center gap-1">
                         <Upload className="w-5 h-5 text-blue-500" />
                         <span className="text-sm font-medium text-blue-600">Drop image here</span>
+                      </div>
+                    ) : pendingIconFile ? (
+                      <div className="flex flex-col items-center gap-1">
+                        <span className="text-sm font-medium text-gray-700">Image selected</span>
+                        <span className="text-xs text-gray-400">Click Save Changes to upload, or pick another</span>
                       </div>
                     ) : (
                       <div className="flex flex-col items-center gap-1">
@@ -853,23 +897,33 @@ const EditCategoryDrawer: React.FC<EditCategoryDrawerProps> = ({
                     setShowTransferModal(true);
                   }
                 }}
-                className="px-3 py-2.5 border border-indigo-300 text-indigo-600 rounded-lg hover:bg-indigo-50 transition-colors flex items-center gap-1.5"
+                disabled={uploadingProfessionIcon === editingProfession._id}
+                className="px-3 py-2.5 border border-indigo-300 text-indigo-600 rounded-lg hover:bg-indigo-50 transition-colors flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
                 title="Transfer to another category"
               >
                 <ArrowRightLeft className="w-4 h-4" />
                 <span className="text-sm hidden sm:inline">Transfer</span>
               </button>
               <button
-                onClick={handleCancelProfessionEdit}
-                className="flex-1 px-4 py-2.5 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                onClick={
+                  uploadingProfessionIcon === editingProfession._id
+                    ? cancelProfessionIconUpload
+                    : handleCancelProfessionEdit
+                }
+                className={`flex-1 px-4 py-2.5 border rounded-lg transition-colors ${
+                  uploadingProfessionIcon === editingProfession._id
+                    ? 'border-red-300 text-red-600 hover:bg-red-50'
+                    : 'border-gray-300 text-gray-700 hover:bg-gray-50'
+                }`}
               >
-                Cancel
+                {uploadingProfessionIcon === editingProfession._id ? 'Cancel Upload' : 'Cancel'}
               </button>
               <button
                 onClick={handleSaveProfessionEdit}
-                className="flex-1 px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                disabled={uploadingProfessionIcon === editingProfession._id}
+                className="flex-1 px-4 py-2.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-blue-600"
               >
-                Save Changes
+                {uploadingProfessionIcon === editingProfession._id ? 'Uploading…' : 'Save Changes'}
               </button>
             </div>
           </div>

--- a/Frontend/src/components/Settings/EditProfessionModal.tsx
+++ b/Frontend/src/components/Settings/EditProfessionModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { X, Upload, Image as ImageIcon } from 'lucide-react';
 import { settingsService } from '../../services';
+import { getProfessionIconByName, generateProfessionIconFilename } from '../../constants/categoryIcons';
 
 interface EditProfessionModalProps {
   isOpen: boolean;
@@ -23,6 +24,16 @@ const EditProfessionModal: React.FC<EditProfessionModalProps> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // What the icon file will be named on ImageKit. A newly uploaded file is always saved as
+  // .webp; renaming an existing icon keeps its current extension (e.g. legacy .png).
+  const targetIconFileName = (() => {
+    if (!name.trim()) return 'profession-name.webp';
+    const slug = generateProfessionIconFilename(name).replace(/\.webp$/, '');
+    if (iconFile) return `${slug}.webp`;
+    const existingExt = profession.icon?.match(/\.([a-z0-9]+)$/i)?.[1];
+    return `${slug}.${existingExt || 'webp'}`;
+  })();
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -158,9 +169,9 @@ const EditProfessionModal: React.FC<EditProfessionModalProps> = ({
                   {iconPreview ? (
                     <img src={iconPreview} alt="Preview" className="w-12 h-12 object-contain" />
                   ) : profession.icon ? (
-                    <img 
-                      src={`/assets/icons/professions/${profession.icon.replace('custom:', '')}?t=${Date.now()}`} 
-                      alt={profession.name} 
+                    <img
+                      src={getProfessionIconByName(profession.icon).imagePath}
+                      alt={profession.name}
                       className="w-12 h-12 object-contain"
                       onError={(e) => {
                         const target = e.target as HTMLImageElement;
@@ -172,7 +183,7 @@ const EditProfessionModal: React.FC<EditProfessionModalProps> = ({
               )}
             </div>
             <p className="text-xs text-gray-500 mt-1">
-              PNG or JPG, max 5MB. Icon will be saved as: {name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '')}.png
+              PNG or JPG, max 5MB. Saved on ImageKit as: {targetIconFileName}
             </p>
           </div>
 

--- a/Frontend/src/components/Transactions/DateRangePicker.tsx
+++ b/Frontend/src/components/Transactions/DateRangePicker.tsx
@@ -19,18 +19,48 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectingStart, setSelectingStart] = useState(true);
+  const [dropdownStyle, setDropdownStyle] = useState<React.CSSProperties>({});
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+    const handleOutside = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+      const insideWrapper = wrapperRef.current?.contains(target);
+      const insideDropdown = dropdownRef.current?.contains(target);
+      if (!insideWrapper && !insideDropdown) {
         setIsOpen(false);
       }
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener('mousedown', handleOutside);
+    document.addEventListener('touchstart', handleOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleOutside);
+      document.removeEventListener('touchstart', handleOutside);
+    };
   }, []);
+
+  // Calculate viewport-safe position for the dropdown
+  useEffect(() => {
+    if (isOpen && buttonRef.current) {
+      const btnRect = buttonRef.current.getBoundingClientRect();
+      const dropdownWidth = 320;
+      const viewportWidth = window.innerWidth;
+      const padding = 8;
+
+      const top = btnRect.bottom + 8;
+      // Prefer right-aligned to button; shift left if overflows right edge
+      let left = btnRect.right - dropdownWidth;
+      if (left < padding) left = padding;
+      if (left + dropdownWidth > viewportWidth - padding) {
+        left = viewportWidth - dropdownWidth - padding;
+      }
+
+      setDropdownStyle({ position: 'fixed', top, left, width: dropdownWidth });
+    }
+  }, [isOpen]);
 
   const getDaysInMonth = (date: Date) => {
     const year = date.getFullYear();
@@ -133,20 +163,21 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
   const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   return (
-    <div className="relative" ref={dropdownRef}>
+    <div className="relative" ref={wrapperRef}>
       <button
+        ref={buttonRef}
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
+        className="w-full flex items-center gap-2 px-3 py-2 bg-white border border-gray-200 rounded-xl hover:bg-gray-50 focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 text-[10px] font-medium shadow-sm"
       >
-        <Calendar className="h-4 w-4 text-gray-400" />
-        <span className="text-gray-700">{formatDisplayDate()}</span>
+        <Calendar className="h-4 w-4 text-gray-400 flex-shrink-0" />
+        <span className="text-gray-700 truncate flex-1 text-left">{formatDisplayDate()}</span>
         {(startDate || endDate) && (
           <button
             onClick={(e) => {
               e.stopPropagation();
               handleClear();
             }}
-            className="ml-2 text-gray-400 hover:text-gray-600"
+            className="ml-1 text-gray-400 hover:text-gray-600 flex-shrink-0"
           >
             <XIcon className="h-3 w-3" />
           </button>
@@ -154,7 +185,11 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
       </button>
 
       {isOpen && (
-        <div className="absolute top-full right-0 mt-2 bg-white border border-gray-200 rounded-lg shadow-lg z-50 p-4 w-80">
+        <div
+          ref={dropdownRef}
+          className="bg-white border border-gray-200 rounded-xl shadow-xl z-[9999] p-4"
+          style={dropdownStyle}
+        >
           <div className="flex gap-2 mb-4 pb-4 border-b border-gray-200">
             <button
               onClick={() => handleQuickSelect(7)}

--- a/Frontend/src/constants/categoryIcons.ts
+++ b/Frontend/src/constants/categoryIcons.ts
@@ -121,6 +121,7 @@ export const getDefaultIconForCategory = (categoryName: string): string => {
 
 export const generateProfessionIconFilename = (professionName: string): string => {
   return professionName
+    .replace(/([a-z])([A-Z])/g, '$1-$2') // camelCase → kebab (parity with backend + Kayod client)
     .toLowerCase()
     .trim()
     .replace(/\s+/g, '-')
@@ -136,20 +137,24 @@ export const getProfessionIconByName = (iconName: string, categoryIcon?: string)
 
   if (iconName.startsWith('ik:')) {
     const filePath = iconName.replace('ik:', '');
-
-    // Use ImageKit URL directly for ik: prefixed icons
-    const imagePath = `${IMAGEKIT_URL_ENDPOINT}${filePath}`;
-
     return {
       name: iconName,
-      imagePath: imagePath,
+      imagePath: `${IMAGEKIT_URL_ENDPOINT}${filePath}`,
       color: '#0F766E',
       label: filePath.split('/').pop()?.replace(/\.[^/.]+$/, '').replace(/-/g, ' ') || 'Profession Icon',
     };
   }
 
-  // For custom: prefixed icons or plain filenames, fall back to default category icon
-  // Only ImageKit icons (ik:) are supported for profession icons
+  if (iconName.startsWith('custom:')) {
+    const fileName = iconName.replace('custom:', '');
+    return {
+      name: iconName,
+      imagePath: `${IMAGEKIT_URL_ENDPOINT}/professionIconsUpload/${fileName}`,
+      color: '#0F766E',
+      label: fileName.replace(/\.[^/.]+$/, '').replace(/-/g, ' '),
+    };
+  }
+
   return categoryIcon ? getIconByName(categoryIcon) : getIconByName('professional-services');
 };
 

--- a/Frontend/src/pages/Transactions.tsx
+++ b/Frontend/src/pages/Transactions.tsx
@@ -13,7 +13,8 @@ import {
   Wallet as WalletIcon,
   LayoutGrid,
   Table2,
-  ChevronRight
+  ChevronRight,
+  Eye
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 
@@ -208,9 +209,9 @@ const Transactions: React.FC = () => {
   };
 
   return (
-    <div className="flex flex-col h-[calc(100vh-4rem)] md:h-screen bg-gray-50 -mx-2 sm:-mx-4 md:-mx-8 lg:-mx-8 -my-2 sm:-my-3 md:-my-4 overflow-hidden">
+    <div className="fixed top-16 md:top-0 bottom-0 left-0 md:left-72 right-0 flex flex-col bg-gray-50 overflow-hidden">
       {/* Header */}
-      <div className="flex-shrink-0 bg-white px-4 md:px-6 py-4 md:py-5 border-b border-gray-200">
+      <div className="flex-shrink-0 bg-white px-4 md:px-6 py-4 md:py-5 border-b border-gray-200 z-30 shadow-sm relative">
         {/* Page Title & Refresh - Desktop only (mobile layout already shows title) */}
         <div className="hidden md:flex flex-col md:flex-row md:items-center md:justify-between mb-4 gap-3">
           <div>
@@ -328,10 +329,10 @@ const Transactions: React.FC = () => {
         </div>
 
         {/* Filter Bar */}
-        <div className="px-4 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row md:items-center gap-3 md:gap-6">
+        <div className="px-4 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col lg:flex-row lg:items-center gap-3 lg:gap-6">
           {/* Row 1 on Mobile / Search on Desktop */}
-          <div className="flex items-center gap-2 md:contents">
-            <div className="relative flex-1 md:order-1">
+          <div className="flex items-center gap-2 lg:contents">
+            <div className="relative flex-1 lg:order-1">
               <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
               <input
                 type="text"
@@ -343,7 +344,7 @@ const Transactions: React.FC = () => {
             </div>
 
             {/* Mobile-only Limit */}
-            <div className="flex md:hidden items-center gap-1.5">
+            <div className="flex lg:hidden items-center gap-1.5">
               <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
@@ -358,9 +359,9 @@ const Transactions: React.FC = () => {
           </div>
 
           {/* Row 2 on Mobile / Desktop Right-side group */}
-          <div className="flex items-center justify-between gap-3 md:flex-initial md:order-2 md:justify-end md:gap-6 shrink-0">
-            <div className="flex-1 md:flex-initial flex items-center gap-2 overflow-x-auto no-scrollbar pb-0.5 md:pb-0">
-              <div className="shrink-0">
+          <div className="flex items-center gap-2 lg:flex-initial lg:order-2 lg:justify-end lg:gap-6 shrink-0">
+            <div className="flex-1 flex items-center gap-2">
+              <div className="flex-1">
                 <DateRangePicker
                   startDate={dateFrom}
                   endDate={dateTo}
@@ -374,7 +375,7 @@ const Transactions: React.FC = () => {
                 <select
                   value={statusFilter}
                   onChange={(e) => setStatusFilter(e.target.value)}
-                  className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-black uppercase tracking-wider text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 md:min-w-[120px]"
+                  className="bg-white px-2.5 py-2 border border-gray-200 rounded-xl shadow-sm text-[10px] font-black uppercase tracking-widest text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 shrink-0"
                 >
                   <option value="all">ALL STATUS</option>
                   <option value="pending">PENDING</option>
@@ -387,7 +388,7 @@ const Transactions: React.FC = () => {
               <select
                 value={paymentMethodFilter}
                 onChange={(e) => setPaymentMethodFilter(e.target.value)}
-                className="bg-white px-3 py-2 border border-gray-200 rounded-xl shadow-sm text-xs font-black uppercase tracking-wider text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 md:min-w-[120px]"
+                className="bg-white px-2.5 py-2 border border-gray-200 rounded-xl shadow-sm text-[10px] font-black uppercase tracking-widest text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/20 shrink-0"
               >
                 <option value="all">ALL METHODS</option>
                 <option value="wallet">WALLET</option>
@@ -397,7 +398,7 @@ const Transactions: React.FC = () => {
             </div>
 
             {/* Pagination Limit for Desktop */}
-            <div className="hidden md:flex items-center gap-2 md:order-3 shrink-0">
+            <div className="hidden lg:flex items-center gap-2 lg:order-3 shrink-0">
               <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
@@ -411,20 +412,23 @@ const Transactions: React.FC = () => {
             </div>
 
             {/* View Type Toggle - Mobile only */}
-            <div className="flex md:hidden items-center bg-white border border-gray-200 rounded-[12px] p-1 shadow-sm shrink-0 md:order-4">
-               <button
-                 onClick={() => setMobileViewType('card')}
-                 className={`p-1.5 rounded-[10px] transition-all ${mobileViewType === 'card' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
-               >
-                 <LayoutGrid className="h-3.5 w-3.5" />
-               </button>
-               <button
-                 onClick={() => setMobileViewType('table')}
-                 className={`p-1.5 rounded-[10px] transition-all ${mobileViewType === 'table' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
-               >
-                 <Table2 className="h-3.5 w-3.5" />
-               </button>
+            <div className="lg:hidden flex items-center bg-white border border-gray-200 rounded-xl p-1 shadow-sm shrink-0">
+              <button
+                onClick={() => setMobileViewType('card')}
+                className={`p-1.5 rounded-lg transition-all ${mobileViewType === 'card' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+                title="Card View"
+              >
+                <LayoutGrid className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => setMobileViewType('table')}
+                className={`p-1.5 rounded-lg transition-all ${mobileViewType === 'table' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+                title="Table View"
+              >
+                <Table2 className="h-4 w-4" />
+              </button>
             </div>
+
           </div>
         </div>
       </div>
@@ -450,7 +454,7 @@ const Transactions: React.FC = () => {
           ) : (
             <>
               {/* Desktop Table View */}
-              <div className="hidden md:block bg-white shadow-sm border-b border-gray-200">
+              <div className="hidden lg:block bg-white shadow-sm border-b border-gray-200">
                 <table className="min-w-full w-full table-fixed">
                   <thead className="bg-gray-50 border-b border-gray-200 sticky top-0 z-10">
                     <tr>
@@ -581,7 +585,7 @@ const Transactions: React.FC = () => {
               </div>
 
               {/* Mobile View */}
-              <div className="md:hidden flex-1 overflow-y-auto">
+              <div className="lg:hidden flex-1 overflow-y-auto">
                 {mobileViewType === 'card' ? (
                   <div className="px-4 py-4 space-y-4">
                     {transactions.map((transaction) => {
@@ -670,8 +674,8 @@ const Transactions: React.FC = () => {
                           >
                             <td className="px-3 py-3 overflow-hidden">
                               <div className="flex items-center gap-2 min-w-0">
-                                <div className="h-8 w-8 rounded-lg bg-gray-50 flex items-center justify-center border border-gray-100 flex-shrink-0">
-                                  {React.cloneElement(getTransactionIcon(transaction, categories) as React.ReactElement, { className: 'h-3.5 w-3.5' })}
+                                <div className="h-8 w-8 rounded-lg bg-gray-50 relative overflow-hidden flex items-center justify-center border border-gray-100 flex-shrink-0">
+                                  {getTransactionIcon(transaction, categories)}
                                 </div>
                                 <div className="min-w-0 flex-1">
                                   <p className="text-[11px] font-black text-gray-900 truncate leading-tight">

--- a/Frontend/src/pages/Verifications.tsx
+++ b/Frontend/src/pages/Verifications.tsx
@@ -11,6 +11,8 @@ import {
   AlertCircle,
   Calendar,
   User,
+  LayoutGrid,
+  Table2,
 } from "lucide-react";
 import toast from "react-hot-toast";
 import { formatDistanceToNow } from "date-fns";
@@ -119,6 +121,7 @@ const Verifications: React.FC = () => {
     page: 1,
     limit: 20,
   });
+  const [mobileViewType, setMobileViewType] = useState<'card' | 'table'>('card');
 
   useEffect(() => {
     const id = searchParams.get("id");
@@ -343,8 +346,8 @@ const Verifications: React.FC = () => {
           </div>
         </div>
 
-        <div className="px-6 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col md:flex-row items-center gap-4">
-          <div className="flex items-center gap-2 w-full md:contents">
+        <div className="px-6 py-3 bg-gray-50/50 border-t border-gray-100 flex flex-col lg:flex-row items-center gap-4">
+          <div className="flex items-center gap-2 w-full lg:contents">
             <div className="relative flex-1">
               <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400 h-4 w-4" />
               <input
@@ -357,7 +360,7 @@ const Verifications: React.FC = () => {
             </div>
 
             {/* Mobile-only Limit */}
-            <div className="flex md:hidden items-center gap-1.5">
+            <div className="flex lg:hidden items-center gap-1.5">
               <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
               <select 
                 value={pagination.limit}
@@ -371,40 +374,60 @@ const Verifications: React.FC = () => {
             </div>
           </div>
 
-          <div className="flex items-center gap-2 p-1 bg-white border border-gray-200 rounded-xl shadow-sm">
-            <button
-              onClick={() => setUserTypeFilter('all')}
-              className={`px-4 py-1.5 text-[11px] font-black uppercase tracking-wider rounded-lg transition-all ${
-                userTypeFilter === 'all'
-                  ? "bg-blue-600 text-white shadow-md"
-                  : "text-gray-500 hover:bg-gray-50"
-              }`}
-            >
-              All Types
-            </button>
-            <button
-              onClick={() => setUserTypeFilter('client')}
-              className={`px-4 py-1.5 text-[11px] font-black uppercase tracking-wider rounded-lg transition-all ${
-                userTypeFilter === 'client'
-                  ? "bg-purple-600 text-white shadow-md"
-                  : "text-gray-500 hover:bg-gray-50"
-              }`}
-            >
-              Customers
-            </button>
-            <button
-              onClick={() => setUserTypeFilter('provider')}
-              className={`px-4 py-1.5 text-[11px] font-black uppercase tracking-wider rounded-lg transition-all ${
-                userTypeFilter === 'provider'
-                  ? "bg-indigo-600 text-white shadow-md"
-                  : "text-gray-500 hover:bg-gray-50"
-              }`}
-            >
-              Providers
-            </button>
+          <div className="flex items-center justify-between w-full lg:contents gap-2">
+            <div className="flex items-center gap-0.5 p-1 bg-white border border-gray-200 rounded-xl shadow-sm">
+              <button
+                onClick={() => setUserTypeFilter('all')}
+                className={`px-2.5 py-1.5 text-[10px] font-black uppercase tracking-wider rounded-lg transition-all whitespace-nowrap ${
+                  userTypeFilter === 'all'
+                    ? "bg-blue-600 text-white shadow-md"
+                    : "text-gray-500 hover:bg-gray-50"
+                }`}
+              >
+                All
+              </button>
+              <button
+                onClick={() => setUserTypeFilter('client')}
+                className={`px-2.5 py-1.5 text-[10px] font-black uppercase tracking-wider rounded-lg transition-all whitespace-nowrap ${
+                  userTypeFilter === 'client'
+                    ? "bg-purple-600 text-white shadow-md"
+                    : "text-gray-500 hover:bg-gray-50"
+                }`}
+              >
+                Customers
+              </button>
+              <button
+                onClick={() => setUserTypeFilter('provider')}
+                className={`px-2.5 py-1.5 text-[10px] font-black uppercase tracking-wider rounded-lg transition-all whitespace-nowrap ${
+                  userTypeFilter === 'provider'
+                    ? "bg-indigo-600 text-white shadow-md"
+                    : "text-gray-500 hover:bg-gray-50"
+                }`}
+              >
+                Providers
+              </button>
+            </div>
+
+            {/* View Type Toggle - Mobile only */}
+            <div className="lg:hidden flex items-center bg-white border border-gray-200 rounded-xl p-1 shadow-sm shrink-0">
+              <button
+                onClick={() => setMobileViewType('card')}
+                className={`p-1.5 rounded-lg transition-all ${mobileViewType === 'card' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+                title="Card View"
+              >
+                <LayoutGrid className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => setMobileViewType('table')}
+                className={`p-1.5 rounded-lg transition-all ${mobileViewType === 'table' ? 'bg-blue-50 text-blue-600 shadow-inner' : 'text-gray-400 hover:text-gray-600'}`}
+                title="Table View"
+              >
+                <Table2 className="h-4 w-4" />
+              </button>
+            </div>
           </div>
 
-          <div className="hidden md:flex items-center gap-2 shrink-0">
+          <div className="hidden lg:flex items-center gap-2 shrink-0">
             <span className="text-[10px] font-black text-gray-400 uppercase tracking-widest whitespace-nowrap">Page Limit</span>
             <select 
               value={pagination.limit}
@@ -529,7 +552,9 @@ const Verifications: React.FC = () => {
               </div>
 
               {/* Mobile View */}
-              <div className="lg:hidden flex-1 overflow-y-auto px-4 py-4 space-y-4">
+              <div className="lg:hidden flex-1 overflow-y-auto">
+              {mobileViewType === 'card' ? (
+                <div className="px-4 py-4 space-y-4">
                 {paginatedUsers.map(({ user, verifications }) => {
                   const latestVerification = verifications[0];
                   const totalDocuments = verifications.reduce((sum, v) => {
@@ -604,6 +629,54 @@ const Verifications: React.FC = () => {
                     </div>
                   );
                 })}
+                </div>
+              ) : (
+                <div className="bg-white">
+                  <table className="w-full table-fixed border-separate border-spacing-0">
+                    <thead className="bg-gray-50/80 sticky top-0 z-20">
+                      <tr>
+                        <th className="w-[50%] px-3 py-3 text-left text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">User</th>
+                        <th className="w-[25%] px-2 py-3 text-center text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Status</th>
+                        <th className="w-[25%] px-3 py-3 text-right text-[9px] font-black text-gray-400 uppercase tracking-widest border-b border-gray-100">Submitted</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-gray-50">
+                      {paginatedUsers.map(({ user, verifications }) => {
+                        const latestVerification = verifications[0];
+                        return (
+                          <tr
+                            key={user._id}
+                            onClick={() => openModal(latestVerification)}
+                            className="active:bg-gray-50 transition-colors"
+                          >
+                            <td className="px-3 py-3 overflow-hidden">
+                              <div className="flex items-center gap-2 min-w-0">
+                                <div className="h-8 w-8 rounded-full relative overflow-hidden flex-shrink-0 border border-gray-100">
+                                  <UserAvatar user={user} size="sm" />
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                  <p className="text-[11px] font-black text-gray-900 truncate leading-tight">{user.name}</p>
+                                  <div className="mt-0.5">
+                                    <UserTypeBadge userType={user.userType} />
+                                  </div>
+                                </div>
+                              </div>
+                            </td>
+                            <td className="px-2 py-3 text-center">
+                              <StatusBadge status={latestVerification.status} />
+                            </td>
+                            <td className="px-3 py-3 text-right">
+                              <p className="text-[10px] font-bold text-gray-500 leading-tight">
+                                {formatDistanceToNow(new Date(latestVerification.submittedAt), { addSuffix: true })}
+                              </p>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
               </div>
 
               {/* Pagination */}

--- a/Frontend/src/services/settingsService.ts
+++ b/Frontend/src/services/settingsService.ts
@@ -97,7 +97,7 @@ export const settingsService = {
     return response.data;
   },
 
-  uploadProfessionIcon: async (file: File, professionName: string, oldIcon?: string, professionId?: string) => {
+  uploadProfessionIcon: async (file: File, professionName: string, oldIcon?: string, professionId?: string, signal?: AbortSignal) => {
     const formData = new FormData();
     formData.append('icon', file);
     formData.append('professionName', professionName);
@@ -111,6 +111,7 @@ export const settingsService = {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
+      signal,
     });
     return response.data;
   },

--- a/Frontend/src/types/support.types.ts
+++ b/Frontend/src/types/support.types.ts
@@ -8,6 +8,7 @@ export interface Message {
   senderId?: string;
   senderName?: string;
   message: string;
+  imageUrl?: string | null;
   timestamp: string;
 }
 

--- a/Frontend/src/utils/apiClient.ts
+++ b/Frontend/src/utils/apiClient.ts
@@ -39,8 +39,14 @@ apiClient.interceptors.response.use(
     return response;
   },
   (error) => {
+    // Request was intentionally cancelled (e.g. user cancelled an upload) — stay silent,
+    // never surface it as a network/connection error.
+    if (axios.isCancel(error)) {
+      return Promise.reject(error);
+    }
+
     const silent404Endpoints = ['/api/verifications/'];
-    const isSilent404 = error.response?.status === 404 && 
+    const isSilent404 = error.response?.status === 404 &&
       silent404Endpoints.some(endpoint => error.config?.url?.includes(endpoint));
     
     if (isNetworkError(error)) {


### PR DESCRIPTION
Backend: introduce generateIconSlug and generateIconFilename; add ImageKit renameFile and safe rename logic when professions are renamed (with rollback on DB failure), staged temp uploads, client-cancel detection, and cleanup of orphaned temp files. Update profession icon upload flow to upload to a temp name then promote to the live name, delete conflicting files, and return full ImageKit URL. Chat support: allow image-only messages (message no longer required), add imageUrl field, include imageUrl in socket payloads, emit all newly pushed messages from change streams (not just last), and use findByIdAndUpdate for accept/close to avoid revalidating large message arrays. Add inter-service notifications to Kayod (axios) to broadcast admin/close/reopen messages and enhance /notify-new-ticket to emit full chat objects. Frontend: render support message attachments and improved ticket summary UI; stage profession icon files locally in EditCategoryDrawer with preview and abortable uploads, upload staged icon only on Save, and update AddProfessionModal to show the generated .webp filename. Misc: update related handlers and services to support the above changes and surface cascade warnings when job/draft updates fail.